### PR TITLE
Add explicit dependency on packaging

### DIFF
--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -4,8 +4,7 @@ import collections
 import re
 import uuid
 
-# pragma pylint: disable=no-name-in-module
-from pkg_resources.extern import packaging
+from packaging.version import Version
 
 import hpcbench
 
@@ -16,7 +15,7 @@ def pip_installer_url(version=None):
     """Get argument to give to ``pip`` to install HPCBench.
     """
     version = version or hpcbench.__version__
-    version = packaging.version.Version(version)
+    version = Version(version)
     version = str(version)
     if '.dev' in version:
         return 'git+http://github.com/tristan0x/hpcbench@master#egg=hpcbench'

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'docopt==0.6.2',
         'elasticsearch==5.4.0',
         'matplotlib==2.0.2',
+        'packaging==16.8',
         'PyYAML>=3.12',
         'six==1.10',
     ],


### PR DESCRIPTION
Do not assume version of `setuptools` installed and explicitly install `packaging`.

Fix #1 