### PR TITLE
Do not use exact version when building a branch with Travis CI

### DIFF
--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -1,6 +1,7 @@
 """HPCBench campaign helper functions
 """
 import collections
+import os
 import re
 import socket
 import uuid
@@ -16,18 +17,12 @@ def pip_installer_url(version=None):
     version = version or hpcbench.__version__
     version = str(version)
     if '.dev' in version:
-        git_rev = None
-        # FIXME: comment git revision extraction because
-        # Jenkins use a merge commit that cannot be installed
-        # with pip to test pull-requests, for instance:
-        # pip install \
-        #    'git+http://github.com/tristan0x/hpcbench@820bf2b#egg=hpcbench'
-        # -> fatal: reference is not a tree: 820bf2b27d86d4fdd657a8e461f4183dc
-        #
-        # git_rev = version.split('+', 1)[-1]
-        # if '.' in git_rev:  # get rid of date suffix
-        #     git_rev = git_rev.split('.', 1)[0]
-        # git_rev = git_rev[1:]  # get rid of scm letter
+        git_rev = 'master'
+        if not os.get('TRAVIS_BRANCH'):
+            git_rev = version.split('+', 1)[-1]
+            if '.' in git_rev:  # get rid of date suffix
+                git_rev = git_rev.split('.', 1)[0]
+            git_rev = git_rev[1:]  # get rid of scm letter
         return 'git+{project_url}@{git_rev}#egg=hpcbench'.format(
             project_url='http://github.com/tristan0x/hpcbench',
             git_rev=git_rev or 'master'

--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -18,7 +18,7 @@ def pip_installer_url(version=None):
     version = str(version)
     if '.dev' in version:
         git_rev = 'master'
-        if not os.get('TRAVIS_BRANCH'):
+        if 'TRAVIS_BRANCH' in os.environ:
             git_rev = version.split('+', 1)[-1]
             if '.' in git_rev:  # get rid of date suffix
                 git_rev = git_rev.split('.', 1)[0]


### PR DESCRIPTION
Jenkins use a merge commit that cannot be installed with pip
to test pull-requests, for instance:

  pip install \
    'git+http://github.com/tristan0x/hpcbench@820bf2b#egg=hpcbench'

produces the following error:

fatal: reference is not a tree: 820bf2b27d86d4fdd657a8e461f4183dc

This patch force to retrieve the master version in this case.