### PR TITLE
Shoc fix

### DIFF
--- a/hpcbench/benchmark/shoc.py
+++ b/hpcbench/benchmark/shoc.py
@@ -103,8 +103,8 @@ class SHOC(Benchmark):
         yield dict(
             category=SHOC.CATEGORY,
             command=[self.executable, '-cuda']
-                    + ["-s", str(self.attributes['size'])]
-                    + ["-d", str(self.attributes['device'])],
+                     + ["-s", str(self.attributes['size'])]
+                     + ["-d", str(self.attributes['device'])],
             metas=dict(
                 benchmark=self.attributes['benchmark']
             ),

--- a/hpcbench/benchmark/shoc.py
+++ b/hpcbench/benchmark/shoc.py
@@ -102,7 +102,9 @@ class SHOC(Benchmark):
         del context  # unused
         yield dict(
             category=SHOC.CATEGORY,
-            command=[self.executable, '-cuda'] + ["-s", str(self.attributes['size'])] + ["-d", str(self.attributes['device'])],
+            command=[self.executable, '-cuda']
+                    + ["-s", str(self.attributes['size'])]
+                    + ["-d", str(self.attributes['device'])],
             metas=dict(
                 benchmark=self.attributes['benchmark']
             ),

--- a/hpcbench/benchmark/shoc.py
+++ b/hpcbench/benchmark/shoc.py
@@ -74,7 +74,7 @@ class SHOC(Benchmark):
     """
     DEFAULT_DEVICE = '0'
     DEFAULT_EXECUTABLE = 'shocdriver'
-    DEFAULT_OPTIONS = ['-s', '3']
+    DEFAULT_SIZE = '1'
     DEFAULT_BENCHMARK = "all"
     CATEGORY = 'gpu'
 
@@ -85,7 +85,7 @@ class SHOC(Benchmark):
                 benchmark=SHOC.DEFAULT_BENCHMARK,
                 device=SHOC.DEFAULT_DEVICE,
                 executable=SHOC.DEFAULT_EXECUTABLE,
-                options=SHOC.DEFAULT_OPTIONS,
+                size=SHOC.DEFAULT_SIZE,
             )
         )
     name = 'shoc'
@@ -102,12 +102,9 @@ class SHOC(Benchmark):
         del context  # unused
         yield dict(
             category=SHOC.CATEGORY,
-            command=[self.executable, '-cuda'] + self.attributes['options'],
+            command=[self.executable, '-cuda'] + ["-s", str(self.attributes['size'])] + ["-d", str(self.attributes['device'])],
             metas=dict(
                 benchmark=self.attributes['benchmark']
-            ),
-            environment=dict(
-                CUDA_VISIBLE_DEVICES=str(self.attributes['device']),
             ),
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ passenv =
   LD_LIBRARY_PATH
   TRAVIS_TAG
 commands =
-	pip install -e .
+	pip install -e .[PLOTTING]
     python setup.py nosetests --with-coverage --cover-inclusive --cover-erase {posargs}
     flake8 hpcbench tests
     -pylint hpcbench --ignore ext

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ passenv =
   LD_LIBRARY_PATH
   TRAVIS_TAG
 commands =
-	pip install -e .[PLOTTING]
+	pip install -e .
     python setup.py nosetests --with-coverage --cover-inclusive --cover-erase {posargs}
     flake8 hpcbench tests
     -pylint hpcbench --ignore ext


### PR DESCRIPTION
Give more flexibility to the show benchmark
- Specify on which GPU it should be executed (option from the corresponding yams)
- Specify the size of the problem 1 by default but it should be 3 to get correct number for GEMM