### PR TITLE
Network tags can now contain a `tags` keyword to refer to other tags

### DIFF
--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -82,6 +82,22 @@ class TestCampaign(unittest.TestCase):
             ]
         )
 
+    def test_cyclic_tags(self):
+        config = self.new_config
+        config['network']['tags']['A'] = dict(
+            tags=['B'])
+        config['network']['tags']['B'] = dict(
+            tags=['A'])
+        with self.assertRaises(Exception):
+            fill_default_campaign_values(config)
+
+    def test_recursive_tag_missing(self):
+        config = self.new_config
+        config['network']['tags']['atag'] = dict(
+            tags=['dontexist'])
+        with self.assertRaises(Exception):
+            fill_default_campaign_values(config)
+
     def test_tags_invalid_mode(self):
         config = self.new_config
         config['network']['tags']['invalid'] = dict(

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -159,6 +159,9 @@ class TestHostDriver(unittest.TestCase):
                         group_match=dict(
                             match="node1.*"
                         ),
+                        group_rectags=dict(
+                            tags=["group_match", "group_nodes"]
+                        ),
                     )
                 )
             )
@@ -185,11 +188,11 @@ class TestHostDriver(unittest.TestCase):
     def test_host_driver_children(self):
         self.assertEqual(
             self.host_driver('node01').children,
-            {'*', 'n01', 'group_nodes'}
+            {'*', 'n01', 'group_nodes', 'group_rectags'}
         )
         self.assertEqual(
             self.host_driver('node10').children,
-            {'*', 'n10', 'group_match'}
+            {'*', 'n10', 'group_match', 'group_rectags'}
         )
 
     def slurm(self, node='node01', tag='group_nodes', srun_nodes=1):


### PR DESCRIPTION
In the network section of a campaign we can now create tags that refer to other tags. The tags keyword has to be followed by a list of tag names.
Extended test cases to check recursive tag expansion and cycle detection.

This closes #85