### PR TITLE
Extract build information from binaries and store into benchmark metas

### DIFF
--- a/hpcbench/benchmark/osu.py
+++ b/hpcbench/benchmark/osu.py
@@ -1,0 +1,291 @@
+"""OSU Micro Benchmarks
+   http://mvapich.cse.ohio-state.edu/benchmarks/
+"""
+from abc import abstractmethod, abstractproperty
+from operator import itemgetter
+import re
+
+from cached_property import cached_property
+
+from hpcbench.api import (
+    Benchmark,
+    Metrics,
+    MetricsExtractor,
+)
+from hpcbench.toolbox.process import find_executable
+
+
+class OSUExtractor(MetricsExtractor):
+    """Abstract class for OSU micro benchmark metrics extractor
+    """
+
+    def __init__(self):
+        self.s_raw_data = []
+
+    @abstractproperty
+    def metrics(self):
+        """Define metrics"""
+
+    @abstractproperty
+    def stdout_ignore_prior(self):
+        """Ignore stdout until this line"""
+
+    @cached_property
+    def metrics_names(self):
+        """get metrics names"""
+        return set(self.metrics)
+
+    def extract_metrics(self, outdir, metas):
+        # parse stdout and extract desired metrics
+        self.prelude()
+        with open(self.stdout(outdir)) as istr:
+            for line in istr:
+                if line.strip() == self.stdout_ignore_prior:
+                    break
+            for line in istr:
+                self.process_line(line.strip())
+        return self.epilog()
+
+    @abstractmethod
+    def process_line(self, line):
+        """Process a line
+        """
+
+    def prelude(self):
+        """method called before extracting metrics"""
+        self.s_raw_data = []
+
+    @abstractmethod
+    def epilog(self):
+        """:return: extracted metrics as a dictionary
+        """
+
+
+class OSUBWExtractor(OSUExtractor):
+    """Metrics extractor for osu_bw benchmark"""
+
+    BW_BANDWIDTH_RE = re.compile(
+        r'^(\d+)[\s]+(\d*\.?\d+)'
+    )
+
+    def __init__(self):
+        super(OSUBWExtractor, self).__init__()
+
+    @cached_property
+    def metrics(self):
+        return dict(max_bw_bytes=Metrics.Byte,
+                    max_bw=Metrics.MegaBytesPerSecond,
+                    maxb_bw_bytes=Metrics.Byte,
+                    maxb_bw=Metrics.MegaBytesPerSecond,
+                    raw=list(dict(
+                        bytes=Metrics.Byte,
+                        bandwidth=Metrics.MegaBytesPerSecond,
+                    )))
+
+    @cached_property
+    def stdout_ignore_prior(self):
+        return "# Size      Bandwidth (MB/s)"
+
+    def process_line(self, line):
+        search = self.BW_BANDWIDTH_RE.search(line)
+        if search:
+            self.s_raw_data.append((int(search.group(1)),
+                                    float(search.group(2))))
+
+    def epilog(self):
+        maxb_bw_b, maxb_bw = self.s_raw_data[-1]
+        max_bw_b, max_bw = max(self.s_raw_data, key=itemgetter(1))
+        return dict(maxb_bw=maxb_bw, maxb_bw_bytes=maxb_bw_b,
+                    max_bw=max_bw, max_bw_bytes=max_bw_b,
+                    raw=[{'bytes': b, 'bandwidth': bw}
+                         for b, bw in self.s_raw_data])
+
+
+class OSULatExtractor(OSUExtractor):
+    """Metrics extractor for osu_bw benchmark"""
+
+    BW_LATENCY_RE = re.compile(
+        r'^(\d+)[\s]+(\d*\.?\d+)'
+    )
+
+    def __init__(self):
+        super(OSULatExtractor, self).__init__()
+
+    @cached_property
+    def metrics(self):
+        return dict(min_lat_bytes=Metrics.Byte,
+                    min_lat=Metrics.Microsecond,
+                    minb_lat_bytes=Metrics.Byte,
+                    minb_lat=Metrics.Microsecond,
+                    raw=list(dict(
+                        bytes=Metrics.Byte,
+                        latency=Metrics.Microsecond,
+                    )))
+
+    @cached_property
+    def stdout_ignore_prior(self):
+        return "# Size          Latency (us)"
+
+    def process_line(self, line):
+        search = self.BW_LATENCY_RE.search(line)
+        if search:
+            bytes = int(search.group(1))
+            if bytes > 0:
+                self.s_raw_data.append((bytes, float(search.group(2))))
+
+    def epilog(self):
+        minb_lat_b, minb_lat = self.s_raw_data[0]
+        min_lat_b, min_lat = min(self.s_raw_data, key=itemgetter(1))
+        return dict(minb_lat=minb_lat, minb_lat_bytes=minb_lat_b,
+                    min_lat=min_lat, min_lat_bytes=min_lat_b,
+                    raw=[{'bytes': b, 'latency': l}
+                         for b, l in self.s_raw_data])
+
+
+class OSUCollectiveLatExtractor(OSUExtractor):
+    """Metrics extractor for osu_bw benchmark"""
+
+    BW_LATENCY_RE = re.compile(
+        r'^(\d+)[\s]+(\d*\.?\d+)'
+    )
+
+    def __init__(self):
+        super(OSUCollectiveLatExtractor, self).__init__()
+
+    @cached_property
+    def metrics(self):
+        return dict(min_lat_bytes=Metrics.Byte,
+                    min_lat=Metrics.Microsecond,
+                    minb_lat_bytes=Metrics.Byte,
+                    minb_lat=Metrics.Microsecond,
+                    raw=list(dict(
+                        bytes=Metrics.Byte,
+                        latency=Metrics.Microsecond,
+                    )))
+
+    @cached_property
+    def stdout_ignore_prior(self):
+        return "# Size       Avg Latency(us)"
+
+    def process_line(self, line):
+        search = self.BW_LATENCY_RE.search(line)
+        if search:
+            bytes = int(search.group(1))
+            if bytes > 0:
+                self.s_raw_data.append((bytes, float(search.group(2))))
+
+    def epilog(self):
+        minb_lat_b, minb_lat = self.s_raw_data[0]
+        min_lat_b, min_lat = min(self.s_raw_data, key=itemgetter(1))
+        return dict(minb_lat=minb_lat, minb_lat_bytes=minb_lat_b,
+                    min_lat=min_lat, min_lat_bytes=min_lat_b,
+                    raw=[{'bytes': b, 'latency': l}
+                         for b, l in self.s_raw_data])
+
+
+class OSU(Benchmark):
+    """Benchmark wrapper for the OSU micro benchmarks
+
+    the `srun_nodes` does not apply to the PingPong benchmark.
+    """
+    OSU_BW = 'osu_bw'
+    OSU_LAT = 'osu_latency'
+    OSU_ALLGATHER = 'osu_allgather'
+    OSU_ALLGATHERV = 'osu_allgatherv'
+    DEFAULT_CATEGORIES = [
+        OSU_BW,
+        OSU_LAT,
+        OSU_ALLGATHER,
+        OSU_ALLGATHERV,
+    ]
+    DEFAULT_ARGUMENTS = {
+        OSU_BW: ["-x", "200", "-i", "100"],
+        OSU_LAT: ["-x", "200", "-i", "100"],
+        OSU_ALLGATHER: ["-x", "200", "-i", "100"],
+        OSU_ALLGATHERV: ["-x", "200", "-i", "100"],
+    }
+
+    def __init__(self):
+        super(OSU, self).__init__(
+            attributes=dict(
+                categories=OSU.DEFAULT_CATEGORIES,
+                arguments=OSU.DEFAULT_ARGUMENTS,
+                srun_nodes=0,
+            )
+        )
+    name = 'osu'
+
+    description = "Provides MPI-based interconnect benchmarking."
+
+    def executable(self, category=None):
+        """Get path to OSU micro benchmark executable
+
+        If no executable is provided then use the category name and find it
+        in the path.
+        """
+        if 'executable' in self.attributes:
+            return self.attributes['executable']
+        else:
+            return category
+
+    @property
+    def categories(self):
+        """List of IMB benchmarks to test"""
+        return self.attributes['categories']
+
+    @property
+    def arguments(self):
+        """Dictionary providing the list of arguments for every
+        benchmark"""
+        return self.attributes['arguments']
+
+    @property
+    def srun_nodes(self):
+        """Number of nodes the benchmark (other than PingPong)
+        must be executed on"""
+        return self.attributes['srun_nodes']
+
+    def execution_matrix(self, context):
+        for category in self.categories:
+            arguments = self.arguments.get(category) or []
+            if category in {OSU.OSU_BW, OSU.OSU_LAT}:
+                for pair in OSU.host_pairs(context):
+                    yield dict(
+                        category=category,
+                        command=[find_executable(self.executable(category))]
+                        + arguments,
+                        srun_nodes=pair,
+                    )
+            else:
+                yield dict(
+                    category=category,
+                    command=[find_executable(self.executable(category))]
+                    + arguments,
+                    srun_nodes=self.srun_nodes
+                )
+
+    @staticmethod
+    def host_pairs(context):
+        try:
+            pos = context.nodes.index(context.node)
+        except ValueError:
+            context.logger.error(
+                'Could not find current node %s in nodes %s',
+                context.node,
+                ', '.join(context.nodes)
+            )
+            return []
+        else:
+            return [
+                [context.node, context.nodes[i]]
+                for i in range(pos + 1, len(context.nodes))
+            ]
+
+    @cached_property
+    def metrics_extractors(self):
+        return {
+            OSU.OSU_BW: OSUBWExtractor(),
+            OSU.OSU_LAT: OSULatExtractor(),
+            OSU.OSU_ALLGATHER: OSUCollectiveLatExtractor(),
+            OSU.OSU_ALLGATHERV: OSUCollectiveLatExtractor(),
+        }

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -548,9 +548,9 @@ class BenchmarkCategoryDriver(Enumerator):
         executable = execution['command'][0]
         try:
             exepath = find_executable(executable, required=True)
-        except NameError as ne:
-            LOGGER.info("Could not find executable to examine for build info")
-            LOGGER.info(str(ne))
+        except NameError:
+            LOGGER.info("Could not find exe %s to examine for build info",
+                        executable)
         else:
             if magic.from_file(exepath).startswith('ELF'):
                 if 'metas' not in execution or execution['metas'] is None:

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -29,6 +29,7 @@ import types
 import uuid
 
 from cached_property import cached_property
+import magic
 import six
 import yaml
 
@@ -40,6 +41,7 @@ from . api import (
 )
 from . campaign import from_file
 from . plot import Plotter
+from . toolbox.buildinfo import extract_build_info
 from . toolbox.collections_ext import (
     dict_merge,
     nameddict,
@@ -542,9 +544,26 @@ class BenchmarkCategoryDriver(Enumerator):
                 MetricsDriver(self.campaign, self.benchmark)(**kwargs)
         self.gather_metrics(runs)
 
+    def _add_build_info(self, execution):
+        executable = execution['command'][0]
+        try:
+            exepath = find_executable(executable, required=True)
+            if magic.from_file(exepath).startswith('ELF'):
+                if 'metas' not in execution or execution['metas'] is None:
+                    execution['metas'] = dict()
+                execution['metas']['build_info'] = extract_build_info(exepath)
+            else:
+                LOGGER.info('{xp} is not pointing to an ELF executable'.format(
+                            xp=exepath))
+        except NameError as ne:
+            LOGGER.info("Could not find executable to examine for build info")
+            LOGGER.info(str(ne))
+
     def _execute(self, **kwargs):
         runs = dict()
         for execution, run_dir in self.children:
+            if 'shell' not in execution:
+                self._add_build_info(execution)
             runs.setdefault(execution['category'], []).append(run_dir)
             with pushd(run_dir, mkdir=True):
                 attempt_cls = self.attempt_run_class(execution)

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -548,16 +548,16 @@ class BenchmarkCategoryDriver(Enumerator):
         executable = execution['command'][0]
         try:
             exepath = find_executable(executable, required=True)
+        except NameError as ne:
+            LOGGER.info("Could not find executable to examine for build info")
+            LOGGER.info(str(ne))
+        else:
             if magic.from_file(exepath).startswith('ELF'):
                 if 'metas' not in execution or execution['metas'] is None:
                     execution['metas'] = dict()
                 execution['metas']['build_info'] = extract_build_info(exepath)
             else:
-                LOGGER.info('{xp} is not pointing to an ELF executable'.format(
-                            xp=exepath))
-        except NameError as ne:
-            LOGGER.info("Could not find executable to examine for build info")
-            LOGGER.info(str(ne))
+                LOGGER.info('%s is not pointing to an ELF executable', exepath)
 
     def _execute(self, **kwargs):
         runs = dict()

--- a/hpcbench/toolbox/buildinfo.py
+++ b/hpcbench/toolbox/buildinfo.py
@@ -2,7 +2,10 @@
 """
 
 import json
-from json import JSONDecodeError
+try:
+    from json import JSONDecodeError as JSONDcdError
+except ImportError:
+    from json import ValueError as JSONDcdError
 import logging
 import subprocess
 
@@ -49,7 +52,7 @@ def extract_build_info(exe_path, elf_section=ELF_SECTION):
         with open(BUILDINFO_FILE) as build_info_f:
             try:
                 build_info = json.load(build_info_f)
-            except JSONDecodeError as jsde:
+            except JSONDcdError as jsde:
                 LOGGER.warning('benchmark executable build is not valid json:')
                 LOGGER.warning(jsde.msg)
                 LOGGER.warning('build info section content:')

--- a/hpcbench/toolbox/buildinfo.py
+++ b/hpcbench/toolbox/buildinfo.py
@@ -5,7 +5,7 @@ import json
 try:
     from json import JSONDecodeError as JSONDcdError
 except ImportError:
-    from json import ValueError as JSONDcdError
+    JSONDcdError = ValueError
 import logging
 import subprocess
 

--- a/hpcbench/toolbox/buildinfo.py
+++ b/hpcbench/toolbox/buildinfo.py
@@ -47,7 +47,7 @@ def extract_build_info(exe_path, elf_section=ELF_SECTION):
                                                          ofile=BUILDINFO_FILE),
                                  exe_path])
         if errno:  # just return the empty dict
-            LOGGER.warning('objcopy failed with errno {:d}'.format(errno))
+            LOGGER.warning('objcopy failed with errno %s', errno)
             return build_info
 
         with open(BUILDINFO_FILE) as build_info_f:

--- a/hpcbench/toolbox/buildinfo.py
+++ b/hpcbench/toolbox/buildinfo.py
@@ -9,6 +9,7 @@ except ImportError:
 import logging
 import subprocess
 
+from hpcbench.toolbox.collections_ext import byteify
 from hpcbench.toolbox.contextlib_ext import (
     mkdtemp,
     pushd,
@@ -51,7 +52,7 @@ def extract_build_info(exe_path, elf_section=ELF_SECTION):
 
         with open(BUILDINFO_FILE) as build_info_f:
             try:
-                build_info = json.load(build_info_f)
+                build_info = json.load(build_info_f, object_hook=byteify)
             except JSONDcdError as jsde:
                 LOGGER.warning('benchmark executable build is not valid json:')
                 LOGGER.warning(jsde.msg)

--- a/hpcbench/toolbox/collections_ext.py
+++ b/hpcbench/toolbox/collections_ext.py
@@ -134,3 +134,16 @@ def dict_map_kv(obj, func):
         return [dict_map_kv(e, func) for e in obj]
     else:
         return func(obj)
+
+
+def byteify(data, ignore_dicts=False):
+    if isinstance(data, six.text_type):
+        if six.PY2:
+            return data.encode('utf-8')
+        else:
+            return data
+    elif isinstance(data, list):
+        return [byteify(el) for el in data]
+    elif not ignore_dicts and isinstance(data, dict):
+        return {byteify(k, ignore_dicts=True): byteify(v)
+                for k, v in data.items()}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,3 @@ pylint==1.8.4
 rednose==1.3.0
 sphinx==1.7.2
 flake8-import-order==0.17.1
-python-magic==0.4.15

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pylint==1.8.4
 rednose==1.3.0
 sphinx==1.7.2
 flake8-import-order==0.17.1
+python-magic==0.4.15

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
 
         [hpcbench.benchmarks]
         babelstream = hpcbench.benchmark.babelstream
+        basic = hpcbench.benchmark.basic
         custream = hpcbench.benchmark.custream
         hpl = hpcbench.benchmark.hpl
         imb = hpcbench.benchmark.imb
@@ -87,6 +88,7 @@ setup(
         iperf = hpcbench.benchmark.iperf
         mdtest = hpcbench.benchmark.mdtest
         nvidia-bandwidthtest = hpcbench.benchmark.nvidia
+        osu = hpcbench.benchmark.osu
         shoc = hpcbench.benchmark.shoc
         standard = hpcbench.benchmark.standard
         stream = hpcbench.benchmark.stream

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'numpy==1.13.3',
         'PyYAML>=3.12',
         'six==1.11',
+        'python-magic==0.4.15'
     ],
     extras_require=dict(
         PLOTTING=[

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ setup(
         'mock==2.0.0',
         'numpy==1.13.3',
         'PyYAML>=3.12',
+        'python-magic==0.4.15',
         'six==1.11',
-        'python-magic==0.4.15'
     ],
     extras_require=dict(
         PLOTTING=[

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -91,7 +91,7 @@ class BuildInfoBench(Benchmark):
                 run_path=None,
             )
         )
-        TestExtractBuildinfo.make_test_dummy('bibench')
+        TestExtractBuildinfo.make_dummy('bibench')
         self.exe_matrix = [dict(
                 category='main',
                 command=[osp.join(os.getcwd(), 'bibench')],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 import inspect
+import os
 import os.path as osp
 import shutil
 import sys
@@ -14,6 +15,7 @@ from hpcbench.api import (
 )
 from hpcbench.cli import bensh
 from hpcbench.toolbox.contextlib_ext import pushd
+from . toolbox.test_buildinfo import TestExtractBuildinfo
 
 
 class DriverTestCase(object):
@@ -32,6 +34,16 @@ class DriverTestCase(object):
     @classmethod
     def tearDownClass(cls):
         shutil.rmtree(cls.TEST_DIR)
+
+
+class NullExtractor(MetricsExtractor):
+
+    @property
+    def metrics(self):
+        return dict()
+
+    def extract_metrics(self, outdir, metas):
+        return dict()
 
 
 class FakeExtractor(MetricsExtractor):
@@ -64,6 +76,42 @@ class FakeExtractor(MetricsExtractor):
             if self.show_cwd:
                 metrics.update(path=content[2].strip())
         return metrics
+
+
+class BuildInfoBench(Benchmark):
+    name = 'buildinfo_tester'
+
+    description = '''
+        fake benchmark for testing build info extraction
+    '''
+
+    def __init__(self):
+        super(BuildInfoBench, self).__init__(
+            attributes=dict(
+                run_path=None,
+            )
+        )
+        TestExtractBuildinfo.make_test_dummy('bibench')
+        self.exe_matrix = [dict(
+                category='main',
+                command=[osp.join(os.getcwd(), 'bibench')],
+                metas=dict())]
+
+    @property
+    def in_campaign_template(self):
+        return False
+
+    @property
+    def build_info(self):
+        return TestExtractBuildinfo.get_json()
+
+    def execution_matrix(self, context):
+        del context
+        return self.exe_matrix
+
+    @property
+    def metrics_extractors(self):
+        return NullExtractor()
 
 
 class FakeBenchmark(Benchmark):

--- a/tests/benchmark/test_osu.osu_allgather.stdout
+++ b/tests/benchmark/test_osu.osu_allgather.stdout
@@ -1,0 +1,7 @@
+# OSU MPI Allgather Latency Test v5.3.2
+# Size       Avg Latency(us)
+64                      8.64
+128                     1.31
+256                     1.58
+512                     1.71
+1024                    1.98

--- a/tests/benchmark/test_osu.osu_allgatherv.stdout
+++ b/tests/benchmark/test_osu.osu_allgatherv.stdout
@@ -1,0 +1,7 @@
+# OSU MPI Allgatherv Latency Test v5.3.2
+# Size       Avg Latency(us)
+64                      1.64
+128                     6.18
+256                     1.84
+512                     2.37
+1024                    3.06

--- a/tests/benchmark/test_osu.osu_bw.stdout
+++ b/tests/benchmark/test_osu.osu_bw.stdout
@@ -1,0 +1,4 @@
+# OSU MPI Bandwidth Test v5.3.2
+# Size      Bandwidth (MB/s)
+2097152             11923.92
+4194304             11952.24

--- a/tests/benchmark/test_osu.osu_latency.stdout
+++ b/tests/benchmark/test_osu.osu_latency.stdout
@@ -1,0 +1,5 @@
+# OSU MPI Latency Test v5.3.2
+# Size          Latency (us)
+16                      3.68
+32                      3.85
+64                      3.84

--- a/tests/benchmark/test_osu.py
+++ b/tests/benchmark/test_osu.py
@@ -1,0 +1,116 @@
+import unittest
+
+from hpcbench.api import ExecutionContext
+from hpcbench.benchmark.osu import OSU
+from . benchmark import AbstractBenchmarkTest
+
+
+class TestOSU(AbstractBenchmarkTest, unittest.TestCase):
+    EXPECTED_METRICS = {
+        OSU.OSU_BW: dict(
+            max_bw=11952.24,
+            max_bw_bytes=4194304,
+            maxb_bw=11952.24,
+            maxb_bw_bytes=4194304,
+            raw=[
+                {'bandwidth': 11923.92, 'bytes': 2097152},
+                {'bandwidth': 11952.24, 'bytes': 4194304},
+            ]
+        ),
+        OSU.OSU_LAT: dict(
+            min_lat=3.68,
+            min_lat_bytes=16,
+            minb_lat=3.68,
+            minb_lat_bytes=16,
+            raw=[
+                {'bytes': 16, 'latency': 3.68},
+                {'bytes': 32, 'latency': 3.85},
+                {'bytes': 64, 'latency': 3.84}
+            ]
+        ),
+        OSU.OSU_ALLGATHER: dict(
+            min_lat=1.31,
+            min_lat_bytes=128,
+            minb_lat=8.64,
+            minb_lat_bytes=64,
+            raw=[
+                {'bytes': 64, 'latency': 8.64},
+                {'bytes': 128, 'latency': 1.31},
+                {'bytes': 256, 'latency': 1.58},
+                {'bytes': 512, 'latency': 1.71},
+                {'bytes': 1024, 'latency': 1.98}
+            ]
+        ),
+        OSU.OSU_ALLGATHERV: dict(
+            min_lat=1.64,
+            min_lat_bytes=64,
+            minb_lat=1.64,
+            minb_lat_bytes=64,
+            raw=[
+                {'bytes': 64, 'latency': 1.64},
+                {'bytes': 128, 'latency': 6.18},
+                {'bytes': 256, 'latency': 1.84},
+                {'bytes': 512, 'latency': 2.37},
+                {'bytes': 1024, 'latency': 3.06}
+            ]
+        ),
+    }
+
+    def get_benchmark_clazz(self):
+        return OSU
+
+    def get_expected_metrics(self, category):
+        return TestOSU.EXPECTED_METRICS[category]
+
+    def get_benchmark_categories(self):
+        return OSU.DEFAULT_CATEGORIES
+
+    @property
+    def attributes(self):
+        return dict(
+            executable='/path/to/fake',
+            srun_nodes=[
+                'node01',
+                'node03',
+                'node05',
+            ]
+        )
+
+    @property
+    def exec_context(self):
+        return ExecutionContext(
+            node='node03',
+            tag='*',
+            nodes=[
+                'node01',
+                'node03',
+                'node05',
+            ],
+            logger=self.logger,
+            srun_options=[],
+        )
+
+    @property
+    def expected_execution_matrix(self):
+        return [
+            dict(
+                command=['/path/to/fake', '-x', '200', '-i', '100'],
+                srun_nodes=['node03', 'node05'],
+                category='osu_bw'
+            ),
+            dict(
+                command=['/path/to/fake', '-x', '200', '-i', '100'],
+                srun_nodes=['node03', 'node05'],
+                category='osu_latency'
+            ),
+            dict(
+                command=['/path/to/fake', '-x', '200', '-i', '100'],
+                srun_nodes=['node01', 'node03', 'node05'],
+                category='osu_allgather'
+            ),
+            dict(
+                command=['/path/to/fake', '-x', '200', '-i', '100'],
+                srun_nodes=['node01', 'node03', 'node05'],
+                category='osu_allgatherv'
+            ),
+        ]

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -208,7 +208,7 @@ class TestHostDriver(unittest.TestCase):
 
     @unittest.skipIf('TRAVIS_TAG' in os.environ,
                      'objcopy version does not support --dump-section yet')
-    def test_builinfo(self):
+    def test_buildinfo(self):
         node = 'node01'
         tag = '*'
         campaign_file = TestHostDriver.CAMPAIGN_FILE

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -29,8 +29,10 @@ from hpcbench.driver import (
 )
 from hpcbench.toolbox.contextlib_ext import (
     capture_stdout,
+    mkdtemp,
+    pushd,
 )
-from . import DriverTestCase, FakeBenchmark
+from . import BuildInfoBench, DriverTestCase, FakeBenchmark
 from . benchmark.benchmark import AbstractBenchmarkTest
 
 
@@ -203,6 +205,32 @@ class TestHostDriver(unittest.TestCase):
             self.host_driver('node10').children,
             {'*', 'n10', 'group_match', 'group_rectags', 'group_localhost'}
         )
+
+    def test_builinfo(self):
+        node = 'node01'
+        tag = '*'
+        campaign_file = TestHostDriver.CAMPAIGN_FILE
+        with mkdtemp() as test_dir, pushd(test_dir):
+            bench = BuildInfoBench()
+            BenchmarkCategoryDriver(
+                BenchmarkDriver(
+                    BenchmarkTagDriver(
+                        HostDriver(
+                            CampaignDriver(
+                                campaign_file=campaign_file,
+                                node=node
+                            ),
+                            node
+                        ),
+                        tag
+                    ),
+                    bench,
+                    dict(),
+                ),
+                'main'
+            )()
+            build_info = bench.execution_matrix(None)[0]['metas']['build_info']
+            self.assertEqual(build_info, bench.build_info)
 
     def slurm(self, **kwargs):
         node = kwargs.get('node', 'node01')

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -206,6 +206,8 @@ class TestHostDriver(unittest.TestCase):
             {'*', 'n10', 'group_match', 'group_rectags', 'group_localhost'}
         )
 
+    @unittest.skipIf('TRAVIS_TAG' in os.environ,
+                     'objcopy version does not support --dump-section yet')
     def test_builinfo(self):
         node = 'node01'
         tag = '*'

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -111,6 +111,8 @@ class TestDriver(DriverTestCase, unittest.TestCase):
 
 
 class TestFakeBenchmark(AbstractBenchmarkTest, unittest.TestCase):
+    exposed_benchmark = False
+
     def get_benchmark_clazz(self):
         return FakeBenchmark
 

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -101,7 +101,7 @@ class TestSlurm(DriverTestCase, unittest.TestCase):
 class TestSbatchTemplate(unittest.TestCase):
     SBATCH_PRELUDE = textwrap.dedent("""\
         #!/bin/bash
-        #SBATCH account={value}
+        #SBATCH --account={value}
         module load nix/spack
         spack load nix
     """)

--- a/tests/test_slurm_default_sbatch_template_per_uc.yaml
+++ b/tests/test_slurm_default_sbatch_template_per_uc.yaml
@@ -15,7 +15,7 @@ process:
     uc1: |
         #!/bin/bash
         {%- for var, val in sbatch_arguments.items() %}
-        #SBATCH {{var}}={{val}}
+        #SBATCH --{{var}}={{val}}
         {%- endfor %}
         module load nix/spack
         spack load nix
@@ -23,7 +23,7 @@ process:
     '*': |
         #!/bin/bash
         {%- for var, val in sbatch_arguments.items() %}
-        #SBATCH {{var}}=forced
+        #SBATCH --{{var}}=forced
         {%- endfor %}
         module load nix/spack
         spack load nix

--- a/tests/test_slurm_embedded_sbatch_template.yaml
+++ b/tests/test_slurm_embedded_sbatch_template.yaml
@@ -14,7 +14,7 @@ process:
   sbatch_template: |
     #!/bin/bash
     {%- for var, val in sbatch_arguments.items() %}
-    #SBATCH {{var}}={{val}}
+    #SBATCH --{{var}}={{val}}
     {%- endfor %}
     module load nix/spack
     spack load nix

--- a/tests/test_slurm_sbatch_template_per_uc.yaml
+++ b/tests/test_slurm_sbatch_template_per_uc.yaml
@@ -15,7 +15,7 @@ process:
     uc1: |
         #!/bin/bash
         {%- for var, val in sbatch_arguments.items() %}
-        #SBATCH {{var}}={{val}}
+        #SBATCH --{{var}}={{val}}
         {%- endfor %}
         module load nix/spack
         spack load nix

--- a/tests/toolbox/test_buildinfo.py
+++ b/tests/toolbox/test_buildinfo.py
@@ -1,4 +1,5 @@
 import json
+import os
 import os.path as osp
 import subprocess
 import unittest
@@ -46,6 +47,8 @@ class TestExtractBuildinfo(unittest.TestCase):
     def get_json(cls):
         return json.loads(DUMMY_BUILDINFO)
 
+    @unittest.skipIf('TRAVIS_TAG' in os.environ,
+                     'objcopy version does not support --dump-section yet')
     def test_extract_build_info(self):
         with mkdtemp() as test_dir, pushd(test_dir):
             TestExtractBuildinfo.make_test_dummy(DUMMY_EXE)

--- a/tests/toolbox/test_buildinfo.py
+++ b/tests/toolbox/test_buildinfo.py
@@ -5,6 +5,7 @@ import subprocess
 import unittest
 
 from hpcbench.toolbox.buildinfo import extract_build_info
+from hpcbench.toolbox.collections_ext import byteify
 from hpcbench.toolbox.contextlib_ext import (
     mkdtemp,
     pushd,
@@ -31,7 +32,7 @@ DUMMY_BUILDINFO = """{
 class TestExtractBuildinfo(unittest.TestCase):
 
     @classmethod
-    def make_test_dummy(cls, dummy='dummy'):
+    def make_dummy(cls, dummy='dummy'):
         with open('dummy.c', 'w') as dummyf:
             dummyf.write(DUMMY_C)
         subprocess.check_call(['gcc', '-O0',
@@ -45,12 +46,13 @@ class TestExtractBuildinfo(unittest.TestCase):
 
     @classmethod
     def get_json(cls):
-        return json.loads(DUMMY_BUILDINFO)
+        return json.loads(DUMMY_BUILDINFO, object_hook=byteify)
 
     @unittest.skipIf('TRAVIS_TAG' in os.environ,
                      'objcopy version does not support --dump-section yet')
     def test_extract_build_info(self):
         with mkdtemp() as test_dir, pushd(test_dir):
-            TestExtractBuildinfo.make_test_dummy(DUMMY_EXE)
+            TestExtractBuildinfo.make_dummy(DUMMY_EXE)
             build_info = extract_build_info(osp.join(test_dir, DUMMY_EXE))
-            self.assertEqual(build_info, json.loads(DUMMY_BUILDINFO))
+            self.assertEqual(build_info, json.loads(DUMMY_BUILDINFO,
+                                                    object_hook=byteify))

--- a/tests/toolbox/test_buildinfo.py
+++ b/tests/toolbox/test_buildinfo.py
@@ -1,0 +1,55 @@
+import json
+import os.path as osp
+import subprocess
+import unittest
+
+from hpcbench.toolbox.buildinfo import extract_build_info
+from hpcbench.toolbox.contextlib_ext import (
+    mkdtemp,
+    pushd,
+)
+
+DUMMY_C = """int main(int argc, char** argv) {
+  return 0;
+}
+"""
+DUMMY_EXE = 'dummy'
+
+DUMMY_BUILDINFO = """{
+  "compiler": {
+    "name": "gcc",
+    "version": "5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.6)"
+  },
+  "opt_flags": ["-O0",
+    "-mtune=intel"
+  ],
+  "build_options": [],
+  "extra_info": "this is a test"
+}
+"""
+
+
+class TestExtractBuildinfo(unittest.TestCase):
+
+    @classmethod
+    def make_test_dummy(cls, dummy='dummy'):
+        with open('dummy.c', 'w') as dummyf:
+            dummyf.write(DUMMY_C)
+        subprocess.check_call(['gcc', '-O0', '-mtune=intel',
+                               '-o', dummy, 'dummy.c'])
+        with open('dummy.buildinfo', 'w') as dummybif:
+            dummybif.write(DUMMY_BUILDINFO)
+        subprocess.check_call(['objcopy', '-I', 'elf64-x86-64',
+                               '-O', 'elf64-x86-64',
+                               '--add-section', 'build_info=dummy.buildinfo',
+                               dummy])
+
+    @classmethod
+    def get_json(cls):
+        return json.loads(DUMMY_BUILDINFO)
+
+    def test_extract_build_info(self):
+        with mkdtemp() as test_dir, pushd(test_dir):
+            TestExtractBuildinfo.make_test_dummy(DUMMY_EXE)
+            build_info = extract_build_info(osp.join(test_dir, DUMMY_EXE))
+            self.assertEqual(build_info, json.loads(DUMMY_BUILDINFO))

--- a/tests/toolbox/test_buildinfo.py
+++ b/tests/toolbox/test_buildinfo.py
@@ -20,9 +20,7 @@ DUMMY_BUILDINFO = """{
     "name": "gcc",
     "version": "5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.6)"
   },
-  "opt_flags": ["-O0",
-    "-mtune=intel"
-  ],
+  "opt_flags": ["-O0"],
   "build_options": [],
   "extra_info": "this is a test"
 }
@@ -35,7 +33,7 @@ class TestExtractBuildinfo(unittest.TestCase):
     def make_test_dummy(cls, dummy='dummy'):
         with open('dummy.c', 'w') as dummyf:
             dummyf.write(DUMMY_C)
-        subprocess.check_call(['gcc', '-O0', '-mtune=intel',
+        subprocess.check_call(['gcc', '-O0',
                                '-o', dummy, 'dummy.c'])
         with open('dummy.buildinfo', 'w') as dummybif:
             dummybif.write(DUMMY_BUILDINFO)


### PR DESCRIPTION
This new feature allows HPCBench to extract a special build_info ELF section that can be included by build systems containing build flags, the configuration and specific dependencies. The information is first extracted using binutils' `objcopy`, parsed as `json` and stored as a dict into the benchmark `metas` dict.