### PR TITLE
OSU benchmarks

### DIFF
--- a/hpcbench/benchmark/osu.py
+++ b/hpcbench/benchmark/osu.py
@@ -1,0 +1,240 @@
+"""OSU Micro Benchmarks
+   http://mvapich.cse.ohio-state.edu/benchmarks/
+"""
+from abc import abstractmethod, abstractproperty
+from operator import itemgetter
+import re
+
+from cached_property import cached_property
+
+from hpcbench.api import (
+    Benchmark,
+    Metrics,
+    MetricsExtractor,
+)
+from hpcbench.toolbox.process import find_executable
+
+
+class OSUExtractor(MetricsExtractor):
+    """Abstract class for OSU micro benchmark metrics extractor
+    """
+    @abstractproperty
+    def metrics(self):
+        """Define metrics"""
+
+    @abstractproperty
+    def stdout_ignore_prior(self):
+        """Ignore stdout until this line"""
+
+    @cached_property
+    def metrics_names(self):
+        """get metrics names"""
+        return set(self.metrics)
+
+    def extract_metrics(self, outdir, metas):
+        # parse stdout and extract desired metrics
+        self.prelude()
+        with open(self.stdout(outdir)) as istr:
+            for line in istr:
+                if line.strip() == self.stdout_ignore_prior:
+                    break
+            for line in istr:
+                self.process_line(line.strip())
+        return self.epilog()
+
+    @abstractmethod
+    def process_line(self, line):
+        """Process a line
+        """
+
+    def prelude(self):
+        """method called before extracting metrics"""
+
+    @abstractmethod
+    def epilog(self):
+        """:return: extracted metrics as a dictionary
+        """
+
+
+class OSUBWExtractor(OSUExtractor):
+    """Metrics extractor for osu_bw benchmark"""
+
+    BW_BANDWIDTH_RE = re.compile(
+        r'^(\d+)[\s]+(\d*\.?\d+)'
+    )
+
+    def __init__(self):
+        super(OSUBWExtractor, self).__init__()
+        self.s_bytes = []
+        self.s_bandwidth = []
+
+    @cached_property
+    def metrics(self):
+        return dict(max_bw_bytes=Metrics.Byte,
+                    max_bw=Metrics.MegaBytesPerSecond,
+                    maxb_bw_bytes=Metrics.Byte,
+                    maxb_bw=Metrics.MegaBytesPerSecond)
+
+    def prelude(self):
+        self.s_bytes.clear()
+        self.s_bandwidth.clear()
+
+    @cached_property
+    def stdout_ignore_prior(self):
+        return "# Size      Bandwidth (MB/s)"
+
+    def process_line(self, line):
+        search = self.BW_BANDWIDTH_RE.search(line)
+        if search:
+            self.s_bytes.append(int(search.group(0)))
+            self.s_bandwidth.append(float(search.group(1)))
+
+    def epilog(self):
+        maxb_bw, maxb_bw_b = self.s_bandwidth[-1], self.s_bytes[-1]
+        max_bw, max_bw_b = max(zip(self.s_bandwidth, self.s_bytes),
+                               key=itemgetter(0))
+        return dict(maxb_bw=maxb_bw, maxb_bw_bytes=maxb_bw_b,
+                    max_bw=max_bw, max_bw_bytes=max_bw_b)
+
+
+class OSULatExtractor(OSUExtractor):
+    """Metrics extractor for osu_bw benchmark"""
+
+    BW_LATENCY_RE = re.compile(
+        r'^(\d+)[\s]+(\d*\.?\d+)'
+    )
+
+    def __init__(self):
+        super(OSULatExtractor, self).__init__()
+        self.s_bytes = []
+        self.s_latency = []
+
+    @cached_property
+    def metrics(self):
+        return dict(mn_lat_bytes=Metrics.Byte,
+                    min_lat=Metrics.Microsecond,
+                    minb_lat_bytes=Metrics.Byte,
+                    minb_lat=Metrics.Microsecond)
+
+    def prelude(self):
+        self.s_bytes.clear()
+        self.s_latency.clear()
+
+    @cached_property
+    def stdout_ignore_prior(self):
+        return "# Size      Bandwidth (MB/s)"
+
+    def process_line(self, line):
+        search = self.BW_LATENCY_RE.search(line)
+        if search:
+            bytes = int(search.group(0))
+            if bytes > 0:
+                self.s_bytes.append(bytes)
+                self.s_latency.append(float(search.group(1)))
+
+    def epilog(self):
+        minb_lat, minb_lat_b = self.s_latency[-1], self.s_bytes[-1]
+        min_lat, min_lat_b = max(zip(self.s_latency, self.s_bytes),
+                               key=itemgetter(0))
+        return dict(minb_lat=minb_lat, minb_lat_bytes=minb_lat_b,
+                    min_lat=min_lat, min_lat_bytes=min_lat_b)
+
+
+class OSU(Benchmark):
+    """Benchmark wrapper for the OSU micro benchmarks
+
+    the `srun_nodes` does not apply to the PingPong benchmark.
+    """
+    OSU_BW = 'osu_bw'
+    OSU_LAT = 'osu_latency'
+    DEFAULT_CATEGORIES = [
+        OSU_BW,
+        OSU_LAT,
+    ]
+    DEFAULT_ARGUMENTS = {
+        OSU_BW: ["-x", "200", "-i", "100"],
+        OSU_LAT: ["-x", "200", "-i", "100"],
+    }
+
+    def __init__(self):
+        super(OSU, self).__init__(
+            attributes=dict(
+                categories=OSU.DEFAULT_CATEGORIES,
+                arguments=OSU.DEFAULT_ARGUMENTS,
+                srun_nodes=0,
+            )
+        )
+    name = 'osu'
+
+    description = "Provides MPI-based interconnect benchmarking."
+
+    def executable(self, category=None):
+        """Get path to OSU micro benchmark executable
+
+        If no executable is provided then use the category name and find it
+        in the path.
+        """
+        if 'executable' in self.attributes:
+            return self.attributes['executable']
+        else:
+           return category
+
+    @property
+    def categories(self):
+        """List of IMB benchmarks to test"""
+        return self.attributes['categories']
+
+    @property
+    def arguments(self):
+        """Dictionary providing the list of arguments for every
+        benchmark"""
+        return self.attributes['arguments']
+
+    @property
+    def srun_nodes(self):
+        """Number of nodes the benchmark (other than PingPong)
+        must be executed on"""
+        return self.attributes['srun_nodes']
+
+    def execution_matrix(self, context):
+        for category in self.categories:
+            arguments = self.arguments.get(category) or []
+            if category == OSU.OSU_BW:
+                for pair in OSU.host_pairs(context):
+                    yield dict(
+                        category=category,
+                        command=[find_executable(self.executable(category))]
+                                + arguments,
+                        srun_nodes=pair,
+                    )
+            else:
+                yield dict(
+                    category=category,
+                    command=[find_executable(self.executable(category))]
+                            + arguments,
+                    srun_nodes=self.srun_nodes
+                )
+
+    @staticmethod
+    def host_pairs(context):
+        try:
+            pos = context.nodes.index(context.node)
+        except ValueError:
+            context.logger.error(
+                'Could not find current node %s in nodes %s',
+                context.node,
+                ', '.join(context.nodes)
+            )
+            return []
+        else:
+            return [
+                [context.node, context.nodes[i]]
+                for i in range(pos + 1, len(context.nodes))
+            ]
+
+    @cached_property
+    def metrics_extractors(self):
+        return {
+            OSU.OSU_BW: OSUBWExtractor(),
+            OSU.OSU_LAT: OSULatExtractor(),
+        }

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
 
         [hpcbench.benchmarks]
         babelstream = hpcbench.benchmark.babelstream
+        basic = hpcbench.benchmark.basic
         custream = hpcbench.benchmark.custream
         hpl = hpcbench.benchmark.hpl
         imb = hpcbench.benchmark.imb
@@ -87,6 +88,7 @@ setup(
         iperf = hpcbench.benchmark.iperf
         mdtest = hpcbench.benchmark.mdtest
         nvidia-bandwidthtest = hpcbench.benchmark.nvidia
+        osu = hpcbench.benchmark.osu
         shoc = hpcbench.benchmark.shoc
         standard = hpcbench.benchmark.standard
         stream = hpcbench.benchmark.stream

--- a/tests/benchmark/test_osu.osu_allgather.stdout
+++ b/tests/benchmark/test_osu.osu_allgather.stdout
@@ -1,0 +1,7 @@
+# OSU MPI Allgather Latency Test v5.3.2
+# Size       Avg Latency(us)
+64                      8.64
+128                     1.31
+256                     1.58
+512                     1.71
+1024                    1.98

--- a/tests/benchmark/test_osu.osu_allgatherv.stdout
+++ b/tests/benchmark/test_osu.osu_allgatherv.stdout
@@ -1,0 +1,7 @@
+# OSU MPI Allgatherv Latency Test v5.3.2
+# Size       Avg Latency(us)
+64                      1.64
+128                     6.18
+256                     1.84
+512                     2.37
+1024                    3.06

--- a/tests/benchmark/test_osu.osu_bw.stdout
+++ b/tests/benchmark/test_osu.osu_bw.stdout
@@ -1,0 +1,4 @@
+# OSU MPI Bandwidth Test v5.3.2
+# Size      Bandwidth (MB/s)
+2097152             11923.92
+4194304             11952.24

--- a/tests/benchmark/test_osu.osu_latency.stdout
+++ b/tests/benchmark/test_osu.osu_latency.stdout
@@ -1,0 +1,5 @@
+# OSU MPI Latency Test v5.3.2
+# Size          Latency (us)
+16                      3.68
+32                      3.85
+64                      3.84

--- a/tests/benchmark/test_osu.py
+++ b/tests/benchmark/test_osu.py
@@ -20,12 +20,38 @@ class TestOSU(AbstractBenchmarkTest, unittest.TestCase):
         OSU.OSU_LAT: dict(
             min_lat=3.68,
             min_lat_bytes=16,
-            minb_lat=3.84,
-            minb_lat_bytes=64,
+            minb_lat=3.68,
+            minb_lat_bytes=16,
             raw=[
                 {'bytes': 16, 'latency': 3.68},
                 {'bytes': 32, 'latency': 3.85},
                 {'bytes': 64, 'latency': 3.84}
+            ]
+        ),
+        OSU.OSU_ALLGATHER: dict(
+            min_lat=1.31,
+            min_lat_bytes=128,
+            minb_lat=8.64,
+            minb_lat_bytes=64,
+            raw=[
+                {'bytes': 64, 'latency': 8.64},
+                {'bytes': 128, 'latency': 1.31},
+                {'bytes': 256, 'latency': 1.58},
+                {'bytes': 512, 'latency': 1.71},
+                {'bytes': 1024, 'latency': 1.98}
+            ]
+        ),
+        OSU.OSU_ALLGATHERV: dict(
+            min_lat=1.64,
+            min_lat_bytes=64,
+            minb_lat=1.64,
+            minb_lat_bytes=64,
+            raw=[
+                {'bytes': 64, 'latency': 1.64},
+                {'bytes': 128, 'latency': 6.18},
+                {'bytes': 256, 'latency': 1.84},
+                {'bytes': 512, 'latency': 2.37},
+                {'bytes': 1024, 'latency': 3.06}
             ]
         ),
     }
@@ -42,7 +68,12 @@ class TestOSU(AbstractBenchmarkTest, unittest.TestCase):
     @property
     def attributes(self):
         return dict(
-            executable='/path/to/fake'
+            executable='/path/to/fake',
+            srun_nodes=[
+                'node01',
+                'node03',
+                'node05',
+            ]
         )
 
     @property
@@ -71,5 +102,15 @@ class TestOSU(AbstractBenchmarkTest, unittest.TestCase):
                 command=['/path/to/fake', '-x', '200', '-i', '100'],
                 srun_nodes=['node03', 'node05'],
                 category='osu_latency'
+            ),
+            dict(
+                command=['/path/to/fake', '-x', '200', '-i', '100'],
+                srun_nodes=['node01', 'node03', 'node05'],
+                category='osu_allgather'
+            ),
+            dict(
+                command=['/path/to/fake', '-x', '200', '-i', '100'],
+                srun_nodes=['node01', 'node03', 'node05'],
+                category='osu_allgatherv'
             ),
         ]

--- a/tests/benchmark/test_osu.py
+++ b/tests/benchmark/test_osu.py
@@ -1,0 +1,75 @@
+import unittest
+
+from hpcbench.api import ExecutionContext
+from hpcbench.benchmark.osu import OSU
+from . benchmark import AbstractBenchmarkTest
+
+
+class TestOSU(AbstractBenchmarkTest, unittest.TestCase):
+    EXPECTED_METRICS = {
+        OSU.OSU_BW: dict(
+            max_bw=11952.24,
+            max_bw_bytes=4194304,
+            maxb_bw=11952.24,
+            maxb_bw_bytes=4194304,
+            raw=[
+                {'bandwidth': 11923.92, 'bytes': 2097152},
+                {'bandwidth': 11952.24, 'bytes': 4194304},
+            ]
+        ),
+        OSU.OSU_LAT: dict(
+            min_lat=3.68,
+            min_lat_bytes=16,
+            minb_lat=3.84,
+            minb_lat_bytes=64,
+            raw=[
+                {'bytes': 16, 'latency': 3.68},
+                {'bytes': 32, 'latency': 3.85},
+                {'bytes': 64, 'latency': 3.84}
+            ]
+        ),
+    }
+
+    def get_benchmark_clazz(self):
+        return OSU
+
+    def get_expected_metrics(self, category):
+        return TestOSU.EXPECTED_METRICS[category]
+
+    def get_benchmark_categories(self):
+        return OSU.DEFAULT_CATEGORIES
+
+    @property
+    def attributes(self):
+        return dict(
+            executable='/path/to/fake'
+        )
+
+    @property
+    def exec_context(self):
+        return ExecutionContext(
+            node='node03',
+            tag='*',
+            nodes=[
+                'node01',
+                'node03',
+                'node05',
+            ],
+            logger=self.logger,
+            srun_options=[],
+        )
+
+    @property
+    def expected_execution_matrix(self):
+        return [
+            dict(
+                command=['/path/to/fake', '-x', '200', '-i', '100'],
+                srun_nodes=['node03', 'node05'],
+                category='osu_bw'
+            ),
+            dict(
+                command=['/path/to/fake', '-x', '200', '-i', '100'],
+                srun_nodes=['node03', 'node05'],
+                category='osu_latency'
+            ),
+        ]

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -111,6 +111,8 @@ class TestDriver(DriverTestCase, unittest.TestCase):
 
 
 class TestFakeBenchmark(AbstractBenchmarkTest, unittest.TestCase):
+    exposed_benchmark = False
+
     def get_benchmark_clazz(self):
         return FakeBenchmark
 


### PR DESCRIPTION
This benchmark module allows running and post-processing:

* osu_latency
* osu_bw
* osu_allgather
* osu_allgatherv

which are the most common benchmarks used for evaluation of interconnect performance.