### PR TITLE
Always generate shell-scripts to execute benchmarks

### DIFF
--- a/docs/campaign.rst
+++ b/docs/campaign.rst
@@ -411,6 +411,24 @@ The ``srun`` layer accepts the following keys:
         - --account=project42
         - --partition=über-cluster
 
+executor_template (optional)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Override default Jinja template used to generate
+shell-scripts in charge of executing benchmarks.
+Default value is:
+
+.. code-block:: shell
+  #!/bin/sh
+
+  {%- for var, value in environment.items() %}
+  export {{ var }}={{ value }}
+  {%- endfor %}
+  cd "{{ cwd }}"
+  exec {{ " ".join(command) }}
+
+If value does not start with shebang, then it is considered
+like a file location.
+
 Environment variable expansion
 ------------------------------
 

--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -62,6 +62,7 @@ DEFAULT_CAMPAIGN = dict(
     process=dict(
         type='local',
         config=dict(),
+        executor_template='executor.sh.jinja'
     ),
     tag=dict(),
     benchmarks={

--- a/hpcbench/templates/executor.sh.jinja
+++ b/hpcbench/templates/executor.sh.jinja
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+{%- for var, value in environment.items() %}
+export {{ var }}={{ value }}
+{%- endfor %}
+cd "{{ cwd }}"
+exec {{ " ".join(command) }}
+


### PR DESCRIPTION
Shell-scripts are based on a Jinja template, which can be
overriden in YAML.