### PR TITLE
Fix buildinfo UT: create intermediate files and executable in tmp

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 import os.path as osp
 import shutil
 import sys
@@ -91,11 +90,14 @@ class BuildInfoBench(Benchmark):
                 run_path=None,
             )
         )
-        TestExtractBuildinfo.make_dummy('bibench')
+        temp_dir = tempfile.mkdtemp(prefix='hpcbench-ut')
+        bibench = osp.join(temp_dir, 'bibench')
+        TestExtractBuildinfo.make_dummy(bibench)
         self.exe_matrix = [dict(
-                category='main',
-                command=[osp.join(os.getcwd(), 'bibench')],
-                metas=dict())]
+            category='main',
+            command=[bibench],
+            metas=dict()
+        )]
 
     @property
     def in_campaign_template(self):

--- a/tests/toolbox/test_buildinfo.py
+++ b/tests/toolbox/test_buildinfo.py
@@ -2,6 +2,7 @@ import json
 import os
 import os.path as osp
 import subprocess
+import tempfile
 import unittest
 
 from hpcbench.toolbox.buildinfo import extract_build_info
@@ -33,15 +34,17 @@ class TestExtractBuildinfo(unittest.TestCase):
 
     @classmethod
     def make_dummy(cls, dummy='dummy'):
-        with open('dummy.c', 'w') as dummyf:
-            dummyf.write(DUMMY_C)
+        fd, c_file = tempfile.mkstemp(suffix='.c')
+        os.write(fd, DUMMY_C.encode('utf-8'))
+        os.close(fd)
         subprocess.check_call(['gcc', '-O0',
-                               '-o', dummy, 'dummy.c'])
-        with open('dummy.buildinfo', 'w') as dummybif:
-            dummybif.write(DUMMY_BUILDINFO)
+                               '-o', dummy, c_file])
+        fd, buildinfo_file = tempfile.mkstemp(suffix='.buildinfo')
+        os.write(fd, DUMMY_BUILDINFO.encode('utf-8'))
+        os.close(fd)
         subprocess.check_call(['objcopy', '-I', 'elf64-x86-64',
                                '-O', 'elf64-x86-64',
-                               '--add-section', 'build_info=dummy.buildinfo',
+                               '--add-section', 'build_info=' + buildinfo_file,
                                dummy])
 
     @classmethod


### PR DESCRIPTION
This PR intends to get rid of the files created in git working copy when executing unit-tests with tox.