### PR TITLE
Adding special sbatch dict into benchmark tags

### DIFF
--- a/docs/campaign.rst
+++ b/docs/campaign.rst
@@ -184,6 +184,30 @@ on every tag.
       check_ram
         type: random_ram_rw
 
+Tag specific sbatch parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When running in :ref:`SLURM mode<process-type>` a special `sbatch` dictionary can be used.
+This dictionary will be used when generating the sbatch file specific to this tag, allowing
+parameters to be overwritten.
+
+.. code-block:: yaml
+  :emphasize-lines: 9-11
+
+  process:
+    type: slurm
+    sbatch:
+      time: 01:00:00
+      tasks-per-node: 1
+
+  benchmarks:
+    cpu:
+      sbatch:
+        hint: compute_bound
+        tasks-per-node: 16
+      test_cpu:
+        type: sysbench
+
 Benchmark configuration reference
 ---------------------------------
 
@@ -405,6 +429,9 @@ This section specifies conditions to filter benchmarks execution.
 Process configuration reference
 -------------------------------
 This section specifies how ``ben-sh`` execute the benchmark commands.
+
+
+.. _process-type:
 
 type (optional)
 ~~~~~~~~~~~~~~~

--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -320,8 +320,9 @@ def get_benchmark_types(campaign):
     :rtype: string generator
     """
     for benchmarks in campaign.benchmarks.values():
-        for benchmark in benchmarks.values():
-            yield benchmark.type
+        for name, benchmark in benchmarks.items():
+            if name != 'sbatch':  # exclude special sbatch name
+                yield benchmark.type
 
 
 def get_metrics(campaign):

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -320,6 +320,10 @@ class SbatchDriver(Enumerator):
     @cached_property
     def sbatch_args(self):
         sbatch_options = self.campaign.process.get('sbatch', {})
+        if self.tag in self.campaign.benchmarks:
+            tag_sbatch_opts = self.campaign.benchmarks[
+                self.tag].get('sbatch', dict())
+            sbatch_options.update(tag_sbatch_opts)
         if 'constraint' not in sbatch_options:
             tag = self.root.network.nodes(self.tag)
             if isinstance(tag, ConstraintTag):
@@ -438,6 +442,10 @@ class BenchmarkTagDriver(Enumerator):
         ]
 
     def _precondition_is_met(self, name):
+        if name == 'sbatch':
+            # this is a special name that does not denote a benchmark
+            # but tag-specific sbatch parameters
+            return False
         config = self.campaign.precondition.get(name)
         if config is None:
             return True

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -384,7 +384,7 @@ class SbatchDriver(Enumerator):
         sbatch_command = [sbatch, '--parsable', self.sbatch_filename]
         sbatch_out = subprocess.check_output(sbatch_command,
                                              universal_newlines=True)
-        jobid = sbatch_out.split(';')[0]
+        jobid = sbatch_out.split(';')[0].strip()
         LOGGER.info("Submitted SBATCH job %s for tag %s",
                     jobid, self.tag)
         return int(jobid)

--- a/tests/test_driver.yaml
+++ b/tests/test_driver.yaml
@@ -4,5 +4,7 @@ network:
     - localhost
 benchmarks:
   '*':
+    sbatch:
+      nodes: 2
     test01:
       type: fake

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -155,7 +155,7 @@ class TestSbatchTemplate(unittest.TestCase):
         self._test_template(
             'test_slurm_default_sbatch_template_per_uc.yaml',
             'uc1',
-            42
+            43
         )
 
         # fallback on default template in YAML
@@ -163,4 +163,12 @@ class TestSbatchTemplate(unittest.TestCase):
             'test_slurm_default_sbatch_template_per_uc.yaml',
             'unknown-uc',
             'forced'
+        )
+
+    def test_per_tag_sbatch_args(self):
+        """Override sbatch arguments in a benchmark tag"""
+        self._test_template(
+            'test_slurm_per_tag_sbatch_args.yaml',
+            'uc1',
+            43
         )

--- a/tests/test_slurm_default_sbatch_template_per_uc.yaml
+++ b/tests/test_slurm_default_sbatch_template_per_uc.yaml
@@ -33,7 +33,7 @@ benchmarks:
   uc1:
     sbatch:
         # this value must be used in sbatch script
-        account: uc1
+        account: 43
     test-slurm:
       type: fake
   uc2:

--- a/tests/test_slurm_per_tag_sbatch_args.yaml
+++ b/tests/test_slurm_per_tag_sbatch_args.yaml
@@ -1,0 +1,34 @@
+network:
+  nodes:
+    - n[1-4]
+  tags:
+    uc1:
+      nodes: [n1, n2]
+    uc2:
+      nodes: [n3, n4]
+
+
+process:
+  type: slurm
+  commands:
+    sbatch: sbatch-ut
+    srun: srun-ut
+  sbatch:
+    account: 42
+  sbatch_template: |
+    #!/bin/bash
+    {%- for var, val in sbatch_arguments.items() %}
+    #SBATCH --{{var}}={{val}}
+    {%- endfor %}
+    module load nix/spack
+    spack load nix
+    {{ hpcbench_command }}
+
+benchmarks:
+  uc1:
+    sbatch:
+        account: 43
+    test-slurm:
+      srun:
+        tasks-per-node: 2
+      type: fake


### PR DESCRIPTION
This allows overwriting the global sbatch configuration setting per tag and sbatch script specific slurm configurations