### PR TITLE
Fix issue where objcopy errors were not caught

### DIFF
--- a/tests/toolbox/test_buildinfo.py
+++ b/tests/toolbox/test_buildinfo.py
@@ -33,12 +33,20 @@ DUMMY_BUILDINFO = """{
 class TestExtractBuildinfo(unittest.TestCase):
 
     @classmethod
-    def make_dummy(cls, dummy='dummy'):
+    def _make_empty_dummy(cls, dummy='dummy'):
         fd, c_file = tempfile.mkstemp(suffix='.c')
         os.write(fd, DUMMY_C.encode('utf-8'))
         os.close(fd)
         subprocess.check_call(['gcc', '-O0',
                                '-o', dummy, c_file])
+
+    @classmethod
+    def make_empty_dummy(cls, dummy='dummy'):
+        cls._make_empty_dummy(dummy)
+
+    @classmethod
+    def make_dummy(cls, dummy='dummy'):
+        cls._make_empty_dummy(dummy)
         fd, buildinfo_file = tempfile.mkstemp(suffix='.buildinfo')
         os.write(fd, DUMMY_BUILDINFO.encode('utf-8'))
         os.close(fd)
@@ -59,3 +67,11 @@ class TestExtractBuildinfo(unittest.TestCase):
             build_info = extract_build_info(osp.join(test_dir, DUMMY_EXE))
             self.assertEqual(build_info, json.loads(DUMMY_BUILDINFO,
                                                     object_hook=byteify))
+
+    @unittest.skipIf('TRAVIS_TAG' in os.environ,
+                     'objcopy version does not support --dump-section yet')
+    def test_no_build_info(self):
+        with mkdtemp() as test_dir, pushd(test_dir):
+            TestExtractBuildinfo.make_empty_dummy(DUMMY_EXE)
+            build_info = extract_build_info(osp.join(test_dir, DUMMY_EXE))
+            self.assertEqual(build_info, {})


### PR DESCRIPTION
Added code and test case to correctly catch when objcopy cannot find a buildinfo section but does not return a non-zero exit code.