### PR TITLE
Fix slurm node restriction when calling srun

### DIFF
--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -340,8 +340,10 @@ class SbatchDriver(Enumerator):
                 # Expand nodelist if --constraint option is not specified
                 # in srun options
                 count = pargs.nodes or len(nodes)
-                sbatch_options.append(
-                    '--nodelist=' + ','.join(self._filter_nodes(nodes, count)))
+                sbatch_options += [
+                    '--nodelist=' + ','.join(self._filter_nodes(nodes, count)),
+                    '--nodes=' + str(count),
+                ]
         return sbatch_options
 
     def _filter_nodes(self, nodes, count):
@@ -1126,7 +1128,10 @@ class SrunExecutionDriver(ExecutionDriver):
             if not pargs.constraint:
                 # Expand nodelist if --constraint option is not specified
                 # in srun options
-                srun_optlist.append('--nodelist=' + ','.join(self.srun_nodes))
+                srun_optlist += [
+                    '--nodelist=' + ','.join(self.srun_nodes),
+                    '--nodes=' + str(len(self.srun_nodes)),
+                ]
         command = super(SrunExecutionDriver, self).command
         return [self.srun] + srun_optlist + command
 

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -158,10 +158,11 @@ class TestSbatchTemplate(unittest.TestCase):
         sbatch.close()
 
     def test_embedded_sbatch_template(self):
-        """Globaly override sbatch template"""
+        """Globally override sbatch template"""
         sbatch_str = "\n".join([
             "#SBATCH --account=42",
-            "#SBATCH --nodelist=n1,n2"
+            "#SBATCH --nodelist=n1,n2",
+            "#SBATCH --nodes=2",
         ])
         self._test_template(
             'test_slurm_embedded_sbatch_template.yaml',
@@ -173,7 +174,8 @@ class TestSbatchTemplate(unittest.TestCase):
         """Override sbatch template per UC"""
         sbatch_str = "\n".join([
             "#SBATCH --account=42",
-            "#SBATCH --nodelist=n1,n2"
+            "#SBATCH --nodelist=n1,n2",
+            "#SBATCH --nodes=2",
         ])
         self._test_template(
             'test_slurm_sbatch_template_per_uc.yaml',
@@ -193,7 +195,8 @@ class TestSbatchTemplate(unittest.TestCase):
         """Override sbatch template per UC with default value"""
         sbatch_str = "\n".join([
             "#SBATCH --account=43",
-            "#SBATCH --nodelist=n1,n2"
+            "#SBATCH --nodelist=n1,n2",
+            "#SBATCH --nodes=2",
         ])
 
         self._test_template(
@@ -203,7 +206,8 @@ class TestSbatchTemplate(unittest.TestCase):
         )
         sbatch_str = "\n".join([
             "#SBATCH --account=42",
-            "#SBATCH --nodelist=n3,n4"
+            "#SBATCH --nodelist=n3,n4",
+            "#SBATCH --nodes=2",
         ])
 
         # fallback on default template in YAML
@@ -217,7 +221,8 @@ class TestSbatchTemplate(unittest.TestCase):
         """Override sbatch arguments in a benchmark tag"""
         sbatch_str = "\n".join([
             "#SBATCH --account=43",
-            "#SBATCH --nodelist=n1,n2"
+            "#SBATCH --nodelist=n1,n2",
+            "#SBATCH --nodes=2",
         ])
         self._test_template(
             'test_slurm_per_tag_sbatch_args.yaml',


### PR DESCRIPTION
Passing `--nodelist` option to srun is not enough, `--nodes` seems
also required.