### PR TITLE
`environment` and `modules` can be specified in execution_context and YAML

### DIFF
--- a/docs/campaign.rst
+++ b/docs/campaign.rst
@@ -362,6 +362,8 @@ environment (optional)
 A dictionary to add environment variables.
 Any boolean values; true, false, yes not, need to be enclosed in quotes to ensure
 they are not converted to python True or False values by the YAML parse.
+If specified, this section supersedes environment variables
+emitted by benchmark.
 
 .. code-block:: yaml
   :emphasize-lines: 5
@@ -373,6 +375,11 @@ they are not converted to python True or False values by the YAML parse.
         environment:
           TEST_ALL: 'true'
           LD_LIBRARY_PATH: /usr/local/lib64
+
+modules (optional)
+~~~~~~~~~~~~~~~~~~
+List of modules to load before executing the command.
+If specified, this section supersedes modules emitted by benchmark.
 
 cwd (optional)
 ~~~~~~~~~~~~~~

--- a/hpcbench/api.py
+++ b/hpcbench/api.py
@@ -231,6 +231,8 @@ class Benchmark(with_metaclass(ABCMeta, object)):
         * *environment* (optional):
             a dictionary providing additional environment variables
             to be given to the executed command
+        * *modules* (optional):
+            list of modules to load before executed the command.
         * *srun_nodes* (optional):
             When the `srun` execution layer is enabled,
             an integer providing the number of required nodes.

--- a/hpcbench/cli/benwait.py
+++ b/hpcbench/cli/benwait.py
@@ -6,11 +6,11 @@ Usage:
   ben-wait --version
 
 Options:
-  -l --log=LOGFILE                   Specify an option logfile to write to
-  -n <seconds>, --interval <seconds> Specify wait interval [default: 10]
-  -h --help                          Show this screen
-  --version                          Show version
-  -v -vv                             Increase program verbosity
+  -l --log=LOGFILE                    Specify an option logfile to write to.
+  -n <seconds>, --interval <seconds>  Specify wait interval [default: 10].
+  -h --help                           Show this screen.
+  --version                           Show version.
+  -v -vv                              Increase program verbosity.
 """
 
 import logging

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -576,6 +576,7 @@ class BenchmarkCategoryDriver(Enumerator):
         super(BenchmarkCategoryDriver, self).__init__(parent, category)
         self.category = category
         self.benchmark = self.parent.benchmark
+        self.config = parent.config
 
     @cached_property
     def commands(self):
@@ -813,6 +814,7 @@ class FixedAttempts(Enumerator):
         super(FixedAttempts, self).__init__(parent)
         self.execution = execution
         self.paths = []
+        self.config = parent.config
 
     __call__ = Enumerator._call_without_report
 
@@ -965,6 +967,7 @@ class ExecutionDriver(Leaf):
         self.command_expansion_vars = dict(
             process_count=1
         )
+        self.config = parent.config
 
     @cached_property
     def _executor_script(self):
@@ -989,14 +992,18 @@ class ExecutionDriver(Leaf):
 
     def _write_executor_script(self, ostr):
         """Write shell script in charge of executing the command"""
+        def merge_attributes(key):
+            env = self.execution.get(key) or {}
+            env.update(self.config.get(key) or {})
+            env = dict((var, six.moves.shlex_quote(str(value)))
+                       for var, value in env.items())
+            return env
+
         properties = dict(
             command=self.command,
             cwd=os.getcwd(),
-            environment=dict(
-                (var, six.moves.shlex_quote(value))
-                for var, value in
-                (self.execution.get('environment') or {}).items()
-            ),
+            modules=self.config.get('modules') or [],
+            environment=merge_attributes('environment'),
         )
         self._jinja_executor_template.stream(**properties).dump(ostr)
 
@@ -1122,7 +1129,7 @@ class SrunExecutionDriver(ExecutionDriver):
         :return: list of string
         """
         srun_options = copy.copy(self.common_srun_options)
-        srun_options.update(self.parent.parent.parent.config.get('srun') or {})
+        srun_options.update(self.config.get('srun') or {})
         srun_optlist = build_slurm_arguments(srun_options)
         if not isinstance(self.root.network.nodes(self.tag), ConstraintTag):
             pargs = parse_constraint_in_args(srun_optlist)

--- a/hpcbench/templates/executor.sh.jinja
+++ b/hpcbench/templates/executor.sh.jinja
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+module purge
+{%- for module in modules %}
+module load {{ module }}
+{%- endfor %}
+
 {%- for var, value in environment.items() %}
 export {{ var }}={{ value }}
 {%- endfor %}

--- a/hpcbench/toolbox/loader.py
+++ b/hpcbench/toolbox/loader.py
@@ -43,11 +43,6 @@ def load_eggs(entry_point_name):
 
         for entry in sorted(working_set.iter_entry_points(entry_point_name),
                             key=lambda entry: entry.name):
-            LOGGER.debug(
-                'Loading %s from %s',
-                entry.name,
-                entry.dist.location
-            )
             try:
                 entry.load(require=True)
             except Exception as exc:  # pylint: disable=broad-except

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,30 @@
+import glob
+import os.path as osp
+from textwrap import dedent
+import unittest
+
+from hpcbench.campaign import ReportNode
+from . import DriverTestCase
+
+
+class TestEnvironment(DriverTestCase, unittest.TestCase):
+    EXPECTED_SHELL_SCRIPT_PRELUDE = dedent("""\
+        #!/bin/sh
+
+        module purge
+        module load foo/bar
+        export foo=bar
+        """)
+
+    def test(self):
+        report = ReportNode(self.CAMPAIGN_PATH)
+        self.assertEqual(
+            report.collect_one('environment'),
+            dict(foo='bar')
+        )
+        path, modules = report.collect_one('modules', with_path=True)
+        self.assertEqual(modules, ['foo/bar'])
+        shell_script = glob.glob(osp.join(path, '*.sh'))[0]
+        with open(shell_script) as istr:
+            expected = self.EXPECTED_SHELL_SCRIPT_PRELUDE
+            self.assertTrue(istr.read().startswith(expected))

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,30 +1,102 @@
+from __future__ import print_function
+
+import contextlib
 import glob
 import os.path as osp
-from textwrap import dedent
 import unittest
 
+from cached_property import cached_property
+import six
+import yaml
+
+from hpcbench.api import Benchmark
 from hpcbench.campaign import ReportNode
-from . import DriverTestCase
+from . import DriverTestCase, NullExtractor
+
+
+class EnvBenchmark(Benchmark):
+    name = "environment"
+    description = "only for testing purpose"
+
+    def __init__(self):
+        super(EnvBenchmark, self).__init__(
+            attributes=dict(
+                environment={},
+                modules=[]
+            )
+        )
+
+    @property
+    def metric_required(self):
+        return False
+
+    @property
+    def metrics_extractors(self):
+        return NullExtractor()
+
+    @property
+    def environment(self):
+        return self.attributes['environment']
+
+    @property
+    def modules(self):
+        return self.attributes['modules']
+
+    def execution_matrix(self, context):
+        yield dict(
+            category='ut',
+            command=['true'],
+            environment=self.environment,
+            modules=self.modules
+        )
 
 
 class TestEnvironment(DriverTestCase, unittest.TestCase):
-    EXPECTED_SHELL_SCRIPT_PRELUDE = dedent("""\
-        #!/bin/sh
+    @classmethod
+    def tearDownClass(cls):
+        pass
 
-        module purge
-        module load foo/bar
-        export foo=bar
-        """)
+    def _shell_prelude(self, environment=None, modules=None):
+        """Rebuild shell-script prelude to ensure that
+        both environment variables and modules are properly
+        set.
+        """
+        environment = environment or {}
+        modules = modules or []
+
+        ostr = six.StringIO()
+        print('#!/bin/sh', file=ostr)
+        print(file=ostr)
+        print('module purge', file=ostr)
+        for module in modules:
+            print('module load ' + module, file=ostr)
+        for name, value in environment.items():
+            print('export', name + '=' + value, file=ostr)
+        with contextlib.closing(ostr):
+            return ostr.getvalue()
+
+    @cached_property
+    def expected_results(self):
+        with open(self.get_campaign_file()) as istr:
+            return yaml.load(istr)['expected_results']
 
     def test(self):
         report = ReportNode(self.CAMPAIGN_PATH)
-        self.assertEqual(
-            report.collect_one('environment'),
-            dict(foo='bar')
-        )
-        path, modules = report.collect_one('modules', with_path=True)
-        self.assertEqual(modules, ['foo/bar'])
-        shell_script = glob.glob(osp.join(path, '*.sh'))[0]
-        with open(shell_script) as istr:
-            expected = self.EXPECTED_SHELL_SCRIPT_PRELUDE
-            self.assertTrue(istr.read().startswith(expected))
+        for path, results in report.collect('modules', 'environment',
+                                            with_path=True):
+            context = report.path_context(path)
+            self.assertIn(context.benchmark, self.expected_results)
+            expected_results = self.expected_results[context.benchmark]
+            self.assertEqual(
+                expected_results['modules'],
+                results[0],
+            )
+            self.assertEqual(
+                expected_results['environment'],
+                results[1],
+            )
+            shell_script = glob.glob(osp.join(path, '*.sh'))[0]
+            with open(shell_script) as istr:
+                prelude = self._shell_prelude(**expected_results)
+                script = istr.read()
+                self.assertTrue(script.startswith(prelude))

--- a/tests/test_environment.yaml
+++ b/tests/test_environment.yaml
@@ -1,10 +1,105 @@
+# results of every benchmark is defined at the end of this file
 benchmarks:
     '*':
-        override:
-            type: fake
+        as_is:
+            # Test benchmark without anything specified
+            type: environment
+        in_attributes:
+            # environment and modules can be specified
+            # by Benchmark.execution_matrix member method
+            type: environment
+            attributes:
+                environment:
+                    FOO: bar
+                modules:
+                - foo/bar
+        in_config:
+            # environment and modules can also be specified
+            # in YAML
+            type: environment
+            environment:
+                FOO: bar
             modules:
             - foo/bar
+        environment_in_config_takes_precedence:
+            # YAML config takes precedence over Benchmark's
+            # environment can be refined
+            type: environment
             environment:
-                foo: bar
+                FOO: pika
+                BAR:
             attributes:
-                input: [10]
+                environment:
+                    FOO: bar
+                    BAR: pika
+        none_modules_in_config_wipes:
+            # None modules wipes them
+            type: environment
+            modules:
+            attributes:
+                modules:
+                - foo/bar
+        empty_modules_in_config_wipes:
+            # None modules wipes them
+            type: environment
+            modules: []
+            attributes:
+                modules:
+                - foo/bar
+        modules_in_config_overrides:
+            # YAML modules completely override Benchmark's
+            type: environment
+            modules:
+            - foo/pika
+            attributes:
+                modules:
+                - foo/bar
+                - bar/pika
+        null_environment_wipes:
+            type: environment
+            environment:
+            attributes:
+                environment:
+                FOO: BAR
+        empty_environment_wipes:
+            type: environment
+            environment: {}
+            attributes:
+                environment:
+                FOO: BAR
+
+
+expected_results:
+    as_is:
+        modules: []
+        environment: {}
+    in_attributes:
+        environment:
+            FOO: bar
+        modules:
+        - foo/bar
+    in_config:
+        environment:
+            FOO: bar
+        modules:
+        - foo/bar
+    environment_in_config_takes_precedence:
+        environment:
+            FOO: pika
+        modules: []
+    none_modules_in_config_wipes:
+        environment: {}
+        modules: []
+    empty_modules_in_config_wipes:
+        environment: {}
+        modules: []
+    modules_in_config_overrides:
+        environment: {}
+        modules:
+        - foo/pika
+    null_environment_wipes:
+        environment: {}
+        modules: []
+    empty_environment_wipes:
+        environment: {}
+        modules: []

--- a/tests/test_environment.yaml
+++ b/tests/test_environment.yaml
@@ -1,0 +1,10 @@
+benchmarks:
+    '*':
+        override:
+            type: fake
+            modules:
+            - foo/bar
+            environment:
+                foo: bar
+            attributes:
+                input: [10]


### PR DESCRIPTION
I modified @ohm314 first implementation so that settings in YAML completely overrides what was specified in `Benchmark.execution_context`, so that the user can completely takes over if needed.

What do you think @ohm314 ?