### PR TITLE
fixed wrong metrics declarations in extractors

### DIFF
--- a/hpcbench/benchmark/imb.py
+++ b/hpcbench/benchmark/imb.py
@@ -34,11 +34,11 @@ class IMBExtractor(MetricsExtractor):
             max_bw_bytes=Metrics.Byte
         )
         if self.with_all_data:
-            common.update(raw=list(dict(
+            common.update(raw=[dict(
                 bytes=Metrics.Byte,
                 bandwidth=Metrics.MegaBytesPerSecond,
                 latency=Metrics.Microsecond,
-            )))
+            )])
         return common
 
     @abstractproperty

--- a/hpcbench/benchmark/osu.py
+++ b/hpcbench/benchmark/osu.py
@@ -80,10 +80,10 @@ class OSUBWExtractor(OSUExtractor):
                     max_bw=Metrics.MegaBytesPerSecond,
                     maxb_bw_bytes=Metrics.Byte,
                     maxb_bw=Metrics.MegaBytesPerSecond,
-                    raw=list(dict(
+                    raw=[dict(
                         bytes=Metrics.Byte,
                         bandwidth=Metrics.MegaBytesPerSecond,
-                    )))
+                    )])
 
     @cached_property
     def stdout_ignore_prior(self):
@@ -120,10 +120,10 @@ class OSULatExtractor(OSUExtractor):
                     min_lat=Metrics.Microsecond,
                     minb_lat_bytes=Metrics.Byte,
                     minb_lat=Metrics.Microsecond,
-                    raw=list(dict(
+                    raw=[dict(
                         bytes=Metrics.Byte,
-                        latency=Metrics.Microsecond,
-                    )))
+                        latency=Metrics.Microsecond
+                    )])
 
     @cached_property
     def stdout_ignore_prior(self):
@@ -161,10 +161,10 @@ class OSUCollectiveLatExtractor(OSUExtractor):
                     min_lat=Metrics.Microsecond,
                     minb_lat_bytes=Metrics.Byte,
                     minb_lat=Metrics.Microsecond,
-                    raw=list(dict(
+                    raw=[dict(
                         bytes=Metrics.Byte,
                         latency=Metrics.Microsecond,
-                    )))
+                    )])
 
     @cached_property
     def stdout_ignore_prior(self):

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -806,6 +806,10 @@ class MetricsDriver(object):
                                                             type(value))
                 raise Exception(message)
             cls._check_metrics(metric, value)
+        else:
+            message = "benchmark metric {} is neither ".format(metric)
+            message += "a Metric, dict or list"
+            raise Exception(message)
 
 
 class FixedAttempts(Enumerator):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 from textwrap import dedent
 
+from cached_property import cached_property
 import six
 
 from hpcbench.api import (
@@ -49,13 +50,13 @@ class FakeExtractor(MetricsExtractor):
     def __init__(self, show_cwd=None):
         self.show_cwd = show_cwd
 
-    @property
+    @cached_property
     def metrics(self):
         metrics = dict(
             performance=Metric('m', float),
             standard_error=Metric('m', float),
-            pairs=list(dict(first=Metric('m', float),
-                            second=Metric('m', bool)))
+            pairs=[dict(first=Metric('m', float),
+                        second=Metric('m', bool))]
         )
         if self.show_cwd:
             metrics.update(path=Metric('', str))


### PR DESCRIPTION
When declaring metric schemas for lists of dicts of metrics we have to make sure not to declare them as list(dict(name: metric) as this decays to [name]. We should instead the syntax [dict(name: metric)].
Also fixed the metrics schema checker to raise an exception when an invalid metric is found.