### PR TITLE
not finding exe should not cause failure in most benchmarks

### DIFF
--- a/hpcbench/benchmark/babelstream.py
+++ b/hpcbench/benchmark/babelstream.py
@@ -126,7 +126,7 @@ class BabelStream(Benchmark):
 
     def _command(self, device):
         cmd = [
-            find_executable(self.executable),
+            find_executable(self.executable, required=False),
             '--device',
             device
         ] + self.options

--- a/hpcbench/benchmark/custream.py
+++ b/hpcbench/benchmark/custream.py
@@ -122,7 +122,7 @@ class CUDAStream(Benchmark):
         for nthreads in self.blocksizes:
             yield dict(
                 category=CUDAStream.name,
-                command=[find_executable(self.executable),
+                command=[find_executable(self.executable, required=False),
                          '-b', nthreads],
                 metas=dict(blocksizes=nthreads),
             )

--- a/hpcbench/benchmark/hpl.py
+++ b/hpcbench/benchmark/hpl.py
@@ -152,7 +152,7 @@ class HPL(Benchmark):
     @property
     def command(self):
         return [
-            find_executable(self.executable),
+            find_executable(self.executable, required=False),
         ] + self.options
 
     def execution_matrix(self, context):

--- a/hpcbench/benchmark/imb.py
+++ b/hpcbench/benchmark/imb.py
@@ -251,16 +251,17 @@ class IMB(Benchmark):
                 for pair in IMB.host_pairs(context):
                     yield dict(
                         category=category,
-                        command=[
-                            find_executable(self.executable),
-                            category
-                        ] + arguments,
+                        command=[find_executable(self.executable,
+                                                 required=False),
+                                 category] + arguments,
                         srun_nodes=pair,
                     )
             else:
                 yield dict(
                     category=category,
-                    command=[self.executable, category] + arguments,
+                    command=[find_executable(self.executable,
+                                             required=False),
+                             category] + arguments,
                     srun_nodes=self.srun_nodes
                 )
 

--- a/hpcbench/benchmark/ior.py
+++ b/hpcbench/benchmark/ior.py
@@ -229,7 +229,7 @@ class IOR(Benchmark):
         cmd = dict(
             category=api,
             command=[
-                find_executable(self.executable),
+                find_executable(self.executable, required=False),
                 '-a', api,
                 '-b', str(self.block_size),
             ] + self.options,

--- a/hpcbench/benchmark/iperf.py
+++ b/hpcbench/benchmark/iperf.py
@@ -110,7 +110,7 @@ class Iperf(Benchmark):
         yield dict(
             category=Iperf.DEFAULT_DEVICE,
             command=self.mpirun + [
-                find_executable(self.executable),
+                find_executable(self.executable, required=False),
                 '-c',
                 self.server,
                 '-J',

--- a/hpcbench/benchmark/nvidia.py
+++ b/hpcbench/benchmark/nvidia.py
@@ -248,7 +248,7 @@ class NvidiaBandwidthTest(Benchmark):
     @property
     def _command(self):
         cmd = [
-            find_executable(self.executable),
+            find_executable(self.executable, required=False),
             '--device',
             str(self.device),
             '--mode',

--- a/hpcbench/benchmark/osu.py
+++ b/hpcbench/benchmark/osu.py
@@ -256,7 +256,8 @@ class OSU(Benchmark):
                     context.logger.warn('Category %s does not support '
                                         'SLURM implicit nodes', category)
                 else:
-                    executable = find_executable(self.executable(category))
+                    executable = find_executable(self.executable(category),
+                                                 required=False)
                     for pair in OSU.host_pairs(context):
                         yield dict(
                             category=category,
@@ -266,7 +267,8 @@ class OSU(Benchmark):
             else:
                 yield dict(
                     category=category,
-                    command=[find_executable(self.executable(category))]
+                    command=[find_executable(self.executable(category),
+                                             required=False)]
                     + arguments,
                     srun_nodes=self.srun_nodes
                 )

--- a/hpcbench/benchmark/shoc.py
+++ b/hpcbench/benchmark/shoc.py
@@ -109,7 +109,7 @@ class SHOC(Benchmark):
     @property
     def command(self):
         return [
-            find_executable(self.executable), '-cuda',
+            find_executable(self.executable, required=False), '-cuda',
             '-d', self.device,
             '-s', self.size,
         ] + self.options

--- a/hpcbench/benchmark/stream.py
+++ b/hpcbench/benchmark/stream.py
@@ -123,7 +123,7 @@ class Stream(Benchmark):
         for thread in self.threads:
             yield dict(
                 category=Stream.name,
-                command=[find_executable(self.executable)],
+                command=[find_executable(self.executable, required=False)],
                 metas=dict(threads=thread),
                 environment=dict(
                     OMP_NUM_THREADS=thread,

--- a/hpcbench/toolbox/process.py
+++ b/hpcbench/toolbox/process.py
@@ -32,7 +32,8 @@ def find_executable(name, names=None, required=True):
        >>> find_executable('sed', names=['gsed'])
 
     required: If True, then the function raises an Exception
-    if the program is not found.
+    if the program is not found else the function returns name if
+    the program is not found.
     """
     path_from_env = os.environ.get(name.upper())
     if path_from_env is not None:
@@ -47,6 +48,8 @@ def find_executable(name, names=None, required=True):
             return eax
     if required:
         raise NameError('Could not find %s executable' % name)
+    else:
+        return name
 
 
 def physical_cpus():

--- a/tests/toolbox/test_process.py
+++ b/tests/toolbox/test_process.py
@@ -11,13 +11,13 @@ class TestFindExecutable(unittest.TestCase):
         os.environ['ELLESSE'] = '/usr/bin/elesse'
         try:
             self.assertEqual(find_executable('ellesse'), '/usr/bin/elesse')
-            self.assertIsNone(find_executable('elaisse', ['elesse'],
-                              required=False))
+            self.assertEqual(find_executable('elaisse', ['elesse'],
+                                             required=False), 'elaisse')
         finally:
             os.environ.pop('ELLESSE')
 
     def test_process_not_found(self):
-        self.assertIsNone(find_executable('ellesse', required=False))
+        self.assertEqual(find_executable('ellesse', required=False), 'ellesse')
         with self.assertRaises(NameError):
             find_executable('ellesse')
             find_executable('ellesse', ['elaisse'])


### PR DESCRIPTION
- changed find_executable semantics to return name if not found and `required=False`.
- changed in most benchmarks the call to find_executable to non-required, i.e. if executable is not found we carry on with the provided name. This behavior is usually more appropriate as executable name could be only resolvbed in the execution script after loading module