### PR TITLE
Set process environment in Benchmark hook member methods

### DIFF
--- a/hpcbench/__init__.py
+++ b/hpcbench/__init__.py
@@ -10,6 +10,6 @@ jinja_environment = Environment(
     autoescape=select_autoescape(
         disabled_extensions=('txt',),
         default_for_string=False,
-        default=True
+        default=False
     ),
 )

--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -566,7 +566,7 @@ class ReportNode(collections.Mapping):
             True
         )
         if has_values:
-            values = tuple([self.data.get(key) for key in keys])
+            values = tuple([self.data[key] for key in keys])
             if len(values) == 1:
                 values = values[0]
             if kwargs.get('with_path', False):

--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -508,11 +508,12 @@ class ReportNode(collections.Mapping):
         """Build of dictionary of fields extracted from
         the given path"""
         prefix = os.path.commonprefix([path, self._path])
-        path = path[len(prefix):]
-        path = path.strip(os.sep)
+        relative_path = path[len(prefix):]
+        relative_path = relative_path.strip(os.sep)
         attrs = ['node', 'tag', 'benchmark', 'category', 'attempt']
-        for i, elt in enumerate(path.split(os.sep)):
+        for i, elt in enumerate(relative_path.split(os.sep)):
             yield attrs[i], elt
+        yield 'path', path
 
     @property
     def report(self):

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -11,6 +11,7 @@ from collections import (
     Mapping,
     namedtuple,
 )
+import contextlib
 import copy
 import datetime
 from functools import wraps
@@ -61,6 +62,7 @@ from . toolbox.contextlib_ext import (
     Timer,
 )
 from . toolbox.edsl import kwargsql
+from . toolbox.environment_modules import module
 from . toolbox.functools_ext import listify
 from .toolbox.process import (
     build_slurm_arguments,
@@ -1084,6 +1086,28 @@ class ExecutionDriver(Leaf):
         return subprocess.Popen([self._executor_script],
                                 stdout=stdout, stderr=stderr)
 
+    @contextlib.contextmanager
+    def module_env(self):
+        """Set current process environment according
+        to execution `environment` and `modules`
+        """
+        env = copy.copy(os.environ)
+        try:
+            for mod in self.execution.get('modules') or []:
+                module('load', mod)
+            os.environ.update(self.execution.get('environment') or {})
+            yield
+        finally:
+            os.environ = env
+
+    def __execute(self, stdout, stderr):
+        with self.module_env():
+            self.benchmark.pre_execute(self.execution)
+        exit_status = self.popen(stdout, stderr).wait()
+        with self.module_env():
+            self.benchmark.post_execute(self.execution)
+        return exit_status
+
     @write_yaml_report
     def __call__(self, **kwargs):
         with open('stdout', 'w') as stdout, \
@@ -1093,14 +1117,9 @@ class ExecutionDriver(Leaf):
                 ctx = self.parent.parent.parent.exec_context
                 cwd = cwd.format(node=ctx.node, tag=ctx.tag)
                 with pushd(cwd):
-                    self.benchmark.pre_execute(self.execution)
-                    exit_status = self.popen(stdout, stderr).wait()
-                    self.benchmark.post_execute(self.execution)
-
+                    exit_status = self.__execute(stdout, stderr)
             else:
-                self.benchmark.pre_execute(self.execution)
-                exit_status = self.popen(stdout, stderr).wait()
-                self.benchmark.post_execute(self.execution)
+                exit_status = self.__execute(stdout, stderr)
         report = dict(
             exit_status=exit_status,
             benchmark=self.benchmark.name,

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -62,7 +62,7 @@ from . toolbox.contextlib_ext import (
     Timer,
 )
 from . toolbox.edsl import kwargsql
-from . toolbox.environment_modules import module
+from . toolbox.environment_modules import Module
 from . toolbox.functools_ext import listify
 from .toolbox.process import (
     build_slurm_arguments,
@@ -1094,7 +1094,7 @@ class ExecutionDriver(Leaf):
         env = copy.copy(os.environ)
         try:
             for mod in self.execution.get('modules') or []:
-                module('load', mod)
+                Module.load(mod)
             os.environ.update(self.execution.get('environment') or {})
             yield
         finally:

--- a/hpcbench/templates/executor.sh.jinja
+++ b/hpcbench/templates/executor.sh.jinja
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-module purge
-{%- for module in modules %}
-module load {{ module }}
-{%- endfor %}
-
+if type module >/dev/null; then
+    module purge
+    {%- for module in modules %}
+    module load {{ module }}
+    {%- endfor %}
+fi
 {%- for var, value in environment.items() %}
 export {{ var }}={{ value }}
 {%- endfor %}

--- a/hpcbench/toolbox/environment_modules.py
+++ b/hpcbench/toolbox/environment_modules.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+
+from . process import find_executable
+
+
+MODULECMD = find_executable('modulecmd', required=False)
+
+
+def module(*args):
+    command = [MODULECMD, 'python'] + list(args)
+    with open(os.devnull, 'w') as devnull:
+        proc = subprocess.Popen(command,
+                                stdout=subprocess.PIPE, stderr=devnull)
+        stdout, _ = proc.communicate()
+        exec(stdout)

--- a/hpcbench/toolbox/environment_modules.py
+++ b/hpcbench/toolbox/environment_modules.py
@@ -1,16 +1,28 @@
 import os
-import subprocess
+from subprocess import PIPE, Popen
 
 from . process import find_executable
 
 
-MODULECMD = find_executable('modulecmd', required=False)
+class Module:
+    MODULECMD = find_executable('modulecmd', required=False)
 
+    @classmethod
+    def load(cls, *args):
+        cls.python('load', *args)
 
-def module(*args):
-    command = [MODULECMD, 'python'] + list(args)
-    with open(os.devnull, 'w') as devnull:
-        proc = subprocess.Popen(command,
-                                stdout=subprocess.PIPE, stderr=devnull)
-        stdout, _ = proc.communicate()
-        exec(stdout)
+    @classmethod
+    def unload(cls, *args):
+        cls.python('load', *args)
+
+    @classmethod
+    def purge(cls, *args):
+        cls.python('purge', *args)
+
+    @classmethod
+    def python(cls, *args):
+        command = [cls.MODULECMD, 'python'] + list(args)
+        with open(os.devnull, 'w') as devnull:
+            proc = Popen(command, shell=False, stdout=PIPE, stderr=devnull)
+            stdout, _ = proc.communicate()
+            exec(stdout)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -2,19 +2,54 @@ from __future__ import print_function
 
 import contextlib
 import glob
+import os
 import os.path as osp
+import re
+import subprocess
 import unittest
 
 from cached_property import cached_property
+import mock
 import six
 import yaml
 
 from hpcbench.api import Benchmark
 from hpcbench.campaign import ReportNode
+from hpcbench.toolbox.environment_modules import MODULECMD
 from . import DriverTestCase, NullExtractor
 
 
+ORIGINAL_POPEN = subprocess.Popen
+
+
+def popen_module_load(command, **kwargs):
+    """Override Popen for every commands starting with
+        modulecmd python load
+
+        >>> p = Popen(['modulecmd', 'python', 'load', 'foo/bar'])
+        >>> p.communicate()
+        ('os.environ["foo_bar"]="loaded"', '')
+        >>>
+    """
+    if command[0:3] != [MODULECMD, 'python', 'load']:
+        return ORIGINAL_POPEN(command, **kwargs)
+    else:
+        module = command[3]
+        env_var = EnvBenchmark.MODULE_TO_VAR_RE.sub('_', module)
+        python_code = 'os.environ["{}"] = "loaded"'.format(env_var)
+
+        class _popen():
+            def communicate(self):
+                return python_code, None
+        return _popen()
+
+
+POPEN_MOCK = mock.Mock(side_effect=popen_module_load)
+
+
 class EnvBenchmark(Benchmark):
+    MODULE_TO_VAR_RE = re.compile('[^0-9a-zA-Z]+')
+
     name = "environment"
     description = "only for testing purpose"
 
@@ -50,12 +85,36 @@ class EnvBenchmark(Benchmark):
             modules=self.modules
         )
 
+    def pre_execute(self, execution):
+        self._dump_environment(execution, 'pre_execute.yaml')
+
+    def post_execute(self, execution):
+        self._dump_environment(execution, 'post_execute.yaml')
+
+    def _dump_environment(self, execution, file):
+        """Write in a YAML file a dict containing sub-set
+        of `os.environ`. Only the following variables are
+        writen:
+        * those in execution['environment']
+        * based on execution['modules'], for instance if module
+          `foo/bar` is specified in execution, then
+          expect `foo_bar` to be in `os.environ`
+        """
+        env_vars = []
+        for module in execution.get('modules') or []:
+            env_vars.append(
+                self.MODULE_TO_VAR_RE.sub('_', module)
+            )
+        for var in execution.get('environment') or {}:
+            env_vars.append(var)
+        with open(file, 'w') as ostr:
+            yaml.dump(
+                dict((name, os.environ.get(name)) for name in env_vars),
+                ostr
+            )
+
 
 class TestEnvironment(DriverTestCase, unittest.TestCase):
-    @classmethod
-    def tearDownClass(cls):
-        pass
-
     def _shell_prelude(self, environment=None, modules=None):
         """Rebuild shell-script prelude to ensure that
         both environment variables and modules are properly
@@ -75,28 +134,53 @@ class TestEnvironment(DriverTestCase, unittest.TestCase):
         with contextlib.closing(ostr):
             return ostr.getvalue()
 
+    @classmethod
+    @mock.patch('subprocess.Popen', new=POPEN_MOCK)
+    def setUpClass(cls):
+        super(cls, cls).setUpClass()
+
     @cached_property
-    def expected_results(self):
+    def expected_env(self):
         with open(self.get_campaign_file()) as istr:
-            return yaml.load(istr)['expected_results']
+            return yaml.safe_load(istr)['expected_env']
 
     def test(self):
         report = ReportNode(self.CAMPAIGN_PATH)
-        for path, results in report.collect('modules', 'environment',
-                                            with_path=True):
+        keys = ('modules', 'environment')
+        for path, env in report.collect(keys, with_path=True):
             context = report.path_context(path)
-            self.assertIn(context.benchmark, self.expected_results)
-            expected_results = self.expected_results[context.benchmark]
-            self.assertEqual(
-                expected_results['modules'],
-                results[0],
-            )
-            self.assertEqual(
-                expected_results['environment'],
-                results[1],
-            )
-            shell_script = glob.glob(osp.join(path, '*.sh'))[0]
-            with open(shell_script) as istr:
-                prelude = self._shell_prelude(**expected_results)
-                script = istr.read()
-                self.assertTrue(script.startswith(prelude))
+            self._check_campaign_report(context, env)
+            self._check_shell_script(context)
+            self._check_benchmark_hooks_environment(context)
+
+    def _check_campaign_report(self, context, env):
+        """Verify environment and modules specified in report"""
+        self.assertIn(context.benchmark, self.expected_env)
+        expected_env = self.expected_env[context.benchmark]
+        self.assertEqual(expected_env['modules'], env[0])
+        self.assertEqual(expected_env['environment'], env[1])
+
+    def _check_shell_script(self, context):
+        """Verify generated shell-script prelude"""
+        shell_script = glob.glob(osp.join(context.path, '*.sh'))[0]
+        environment = self.expected_env[context.benchmark]
+        with open(shell_script) as istr:
+            prelude = self._shell_prelude(**environment)
+            script = istr.read()
+            self.assertTrue(script.startswith(prelude))
+
+    def _check_benchmark_hooks_environment(self, context):
+        """Check hook file written by benchmark
+        `pre_execute` and `post_execute` member methods"""
+        environment = self.expected_env[context.benchmark]
+        for hook_file_prefix in ['pre', 'post']:
+            hook_file = osp.join(context.path,
+                                 hook_file_prefix + '_execute.yaml')
+            with open(hook_file) as istr:
+                hook_env = yaml.safe_load(istr)
+            for var, value in environment['environment'].items():
+                self.assertEqual(hook_env[var], value)
+                hook_env.pop(var)
+            for module in environment['modules']:
+                var = EnvBenchmark.MODULE_TO_VAR_RE.sub('_', module)
+                self.assertEqual(hook_env[var], 'loaded')

--- a/tests/test_environment.yaml
+++ b/tests/test_environment.yaml
@@ -67,9 +67,24 @@ benchmarks:
             attributes:
                 environment:
                 FOO: BAR
+        dollar_in_variable:
+            type: environment
+            attributes:
+                environment:
+                  FOO: "$$BAR"
+        space_in_variable:
+            type: environment
+            attributes:
+                environment:
+                  FOO: foo bar
+        quotes_in_variable:
+            type: environment
+            attributes:
+                environment:
+                  FOO: "foo'\"bar"
 
 
-expected_results:
+expected_env:
     as_is:
         modules: []
         environment: {}
@@ -102,4 +117,16 @@ expected_results:
         modules: []
     empty_environment_wipes:
         environment: {}
+        modules: []
+    dollar_in_variable:
+        environment:
+            FOO: "$$BAR"
+        modules: []
+    quotes_in_variable:
+        environment:
+            FOO: "foo'\"bar"
+        modules: []
+    space_in_variable:
+        environment:
+            FOO: foo bar
         modules: []


### PR DESCRIPTION
Set environment in `pre_execute` and `post_execute` member methods
according to `environment` and `modules` execution settings.