### PR TITLE
disable autoescaping for strings in jinja templates

### DIFF
--- a/hpcbench/__init__.py
+++ b/hpcbench/__init__.py
@@ -9,7 +9,7 @@ jinja_environment = Environment(
     loader=PackageLoader('hpcbench', 'templates'),
     autoescape=select_autoescape(
         disabled_extensions=('txt',),
-        default_for_string=True,
+        default_for_string=False,
         default=True
     ),
 )


### PR DESCRIPTION
The strings are escaped to HTML which causes e.g. slurm jobs to crash since constraints may contain escaped characters.