### PR TITLE
Added execution context into pre_execute and post_execute hooks

### DIFF
--- a/hpcbench/api.py
+++ b/hpcbench/api.py
@@ -287,6 +287,8 @@ class Benchmark(with_metaclass(ABCMeta, object)):
 
         :param execution: one of the dictionary
                           provided in ``execution_matrix`` member method.
+        :param context: `ExecutionContext` instance. See ``execution_matrix``
+                        member method for more details.
         """
         del execution  # unused
         del context  # unused
@@ -297,6 +299,8 @@ class Benchmark(with_metaclass(ABCMeta, object)):
 
         :param execution: one of the dictionary
                           provided in ``execution_matrix`` member method.
+        :param context: `ExecutionContext` instance. See ``execution_matrix``
+                        member method for more details.
         """
         del execution  # unused
         del context  # unused

--- a/hpcbench/api.py
+++ b/hpcbench/api.py
@@ -281,7 +281,7 @@ class Benchmark(with_metaclass(ABCMeta, object)):
         """
         raise NotImplementedError  # pragma: no cover
 
-    def pre_execute(self, execution):
+    def pre_execute(self, execution, context):
         """Method called before executing one of the commands.
         Current working directory is the execution directory.
 
@@ -289,8 +289,9 @@ class Benchmark(with_metaclass(ABCMeta, object)):
                           provided in ``execution_matrix`` member method.
         """
         del execution  # unused
+        del context  # unused
 
-    def post_execute(self, execution):
+    def post_execute(self, execution, context):
         """Method called after executing one of the commands.
         Current working directory is the execution directory.
 
@@ -298,6 +299,7 @@ class Benchmark(with_metaclass(ABCMeta, object)):
                           provided in ``execution_matrix`` member method.
         """
         del execution  # unused
+        del context  # unused
 
     @abstractproperty
     def metrics_extractors(self):

--- a/hpcbench/benchmark/basic.py
+++ b/hpcbench/benchmark/basic.py
@@ -78,6 +78,7 @@ class Basic(Benchmark):
 
     def pre_execute(self, execution, context):
         del execution  # unused
+        del context  # unused
         with open(Basic.PING_IPS_FILE, 'w') as ostr:
             for ip in self.ping_ips:
                 print(ip, file=ostr)

--- a/hpcbench/benchmark/basic.py
+++ b/hpcbench/benchmark/basic.py
@@ -76,7 +76,7 @@ class Basic(Benchmark):
             command=[Basic.EXECUTABLE]
         )
 
-    def pre_execute(self, execution):
+    def pre_execute(self, execution, context):
         del execution  # unused
         with open(Basic.PING_IPS_FILE, 'w') as ostr:
             for ip in self.ping_ips:

--- a/hpcbench/benchmark/hpl.py
+++ b/hpcbench/benchmark/hpl.py
@@ -210,6 +210,6 @@ class HPL(Benchmark):
     def metrics_extractors(self):
         return HPLExtractor()
 
-    def pre_execute(self, execution):
+    def pre_execute(self, execution, context):
         with open('HPL.dat', 'w') as ostr:
             ostr.write(self.data)

--- a/hpcbench/benchmark/mdtest.py
+++ b/hpcbench/benchmark/mdtest.py
@@ -186,7 +186,7 @@ class MDTest(Benchmark):
             if opt == '-d' and len(command) > i + 1:
                 return command[i + 1]
 
-    def post_execute(self, execution):
+    def post_execute(self, execution, context):
         if self.post_cleanup:
             test_dir = MDTest._get_path_from_execution(execution)
             if test_dir and osp.isdir(test_dir):

--- a/hpcbench/benchmark/minigemm.py
+++ b/hpcbench/benchmark/minigemm.py
@@ -256,7 +256,7 @@ class MiniGEMM(Benchmark):
             ),
         )
 
-    def _compile(self, execution):
+    def _compile(self, execution, context):
         with open('minigemm.cpp', 'w') as ostr:
             print(SOURCE, file=ostr)
         with open('Makefile', 'w') as ostr:
@@ -266,10 +266,17 @@ class MiniGEMM(Benchmark):
             print(COMPILE_SCRIPT.format(opts=opt_str), file=ostr)
         st = os.stat('compile.sh')
         os.chmod('compile.sh', st.st_mode | stat.S_IEXEC)
-        subprocess.check_call(['./compile.sh'])
+        try:
+            subprocess.check_call(['./compile.sh'])
+        except subprocess.CalledProcessError as cpe:
+            context.logger.warning(
+                'minigemm compilation failed, error code:',
+                cpe.returncode)
+        else:
+            context.logger.info('Successfully compiled minigemm benchmark')
 
-    def pre_execute(self, execution):
-        self._compile(execution)
+    def pre_execute(self, execution, context):
+        self._compile(execution, context)
 
     @cached_property
     def metrics_extractors(self):

--- a/hpcbench/driver.py
+++ b/hpcbench/driver.py
@@ -187,7 +187,7 @@ class Leaf(Enumerator):
         return []
 
 
-Top = namedtuple('top', ['campaign', 'node', 'logger', 'root'])
+Top = namedtuple('top', ['campaign', 'node', 'logger', 'root', 'name'])
 Top.__new__.__defaults__ = (None, ) * len(Top._fields)
 
 
@@ -590,6 +590,7 @@ class BenchmarkCategoryDriver(Enumerator):
         self.category = category
         self.benchmark = self.parent.benchmark
         self.config = parent.config
+        self.exec_context = parent.exec_context
 
     @cached_property
     def commands(self):
@@ -850,6 +851,7 @@ class FixedAttempts(Enumerator):
         self.execution = execution
         self.paths = []
         self.config = parent.config
+        self.exec_context = parent.exec_context
 
     __call__ = Enumerator._call_without_report
 
@@ -1003,6 +1005,7 @@ class ExecutionDriver(Leaf):
             process_count=1
         )
         self.config = parent.config
+        self.exec_context = parent.exec_context
 
     @cached_property
     def _executor_script(self):
@@ -1113,10 +1116,10 @@ class ExecutionDriver(Leaf):
 
     def __execute(self, stdout, stderr):
         with self.module_env():
-            self.benchmark.pre_execute(self.execution)
+            self.benchmark.pre_execute(self.execution, self.exec_context)
         exit_status = self.popen(stdout, stderr).wait()
         with self.module_env():
-            self.benchmark.post_execute(self.execution)
+            self.benchmark.post_execute(self.execution, self.exec_context)
         return exit_status
 
     @write_yaml_report

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -140,7 +140,9 @@ class FakeBenchmark(Benchmark):
             )
         )
 
-    def pre_execute(self, execution):
+    def pre_execute(self, execution, context):
+        del execution  # unused
+        del context  # unused
         with open('test.py', 'w') as ostr:
             ostr.write(dedent("""\
             from __future__ import print_function
@@ -177,27 +179,3 @@ class FakeBenchmark(Benchmark):
     @property
     def metrics_extractors(self):
         return dict(main=FakeExtractor(self.attributes['run_path']))
-
-    @property
-    def plots(self):
-        return dict(
-            main=[
-                dict(
-                    name="{hostname} {category} Performance",
-                    series=dict(
-                        metas=['field'],
-                        metrics=[
-                            'performance',
-                            'standard_error'
-                        ],
-                    ),
-                    plotter=self.plot_performance
-                )
-            ]
-        )
-
-    def plot_performance(self, plt, description, metas, metrics):
-        plt.errorbar(metas['field'],
-                     metrics['performance'],
-                     yerr=metrics['standard_error'],
-                     fmt='o', ecolor='g', capthick=2)

--- a/tests/benchmark/test_mdtest.py
+++ b/tests/benchmark/test_mdtest.py
@@ -27,13 +27,14 @@ class TestMDTestPostExecution(unittest.TestCase):
             post_cleanup=True,
             options=['foo', '-d', path]
         )
-        execution = next(mdt.execution_matrix(ExecutionContext(
+        exec_ctx = mdt.execution_matrix(ExecutionContext(
             node='node.local',
             tag='tag.name',
             nodes=[],
             logger=LOGGER,
             srun_options=None,
-        )))
+        ))
+        execution = next(exec_ctx)
         path = execution['command'][-1]
         self.assertTrue(path.endswith('node.local--tag.name'))
         os.mkdir(path)
@@ -41,7 +42,7 @@ class TestMDTestPostExecution(unittest.TestCase):
             pass
         if fill_dir:
             TestMDTestPostExecution.fill_directory(path)
-        mdt.post_execute(execution)
+        mdt.post_execute(execution, exec_ctx)
         self.assertEqual(os.listdir(path), ['stderr.txt'])
 
     def test_empty_dir(self):

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -16,12 +16,12 @@ from hpcbench.cli import bensh
 from hpcbench.driver import (
     BenchmarkCategoryDriver,
     BenchmarkDriver,
+    BenchmarkTagDriver,
     CampaignDriver,
     ConstraintTag,
     ExecutionDriver,
     FixedAttempts,
-    Top,
-)
+    HostDriver)
 from hpcbench.toolbox.contextlib_ext import modified_environ
 
 
@@ -191,7 +191,12 @@ class TestBenchmark(unittest.TestCase):
             FixedAttempts(
                 BenchmarkCategoryDriver(
                     BenchmarkDriver(
-                        Top(logger=LOGGER),
+                        BenchmarkTagDriver(
+                            HostDriver(
+                                CampaignDriver(default_campaign()),
+                                'n1'
+                            )
+                        ),
                         namedtuple('benchmark', ['name'])(name='benchmark'),
                         dict(exec_prefix=exec_prefix),
                     ),

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -82,10 +82,12 @@ class EnvBenchmark(Benchmark):
             metas=dict(foo='foo')
         )
 
-    def pre_execute(self, execution):
+    def pre_execute(self, execution, context):
+        del context  # unused
         self._dump_environment(execution, 'pre_execute.yaml')
 
-    def post_execute(self, execution):
+    def post_execute(self, execution, context):
+        del context  # unused
         self._dump_environment(execution, 'post_execute.yaml')
 
     def _dump_environment(self, execution, file):


### PR DESCRIPTION
Benchmark pre_execute and post_execute hooks can now access the same execution context that the main execution has. This allows them to use for instance the logger.
This closes #184 