### PR TITLE
Don't expand the campaign when not in data generation mode

### DIFF
--- a/hpcbench/campaign.py
+++ b/hpcbench/campaign.py
@@ -221,7 +221,8 @@ def default_campaign(campaign=None, expandcampvars=True, frozen=True):
         campaign = nameddict(dict_map_kv(campaign, _expandvars))
     else:
         campaign = nameddict(campaign)
-    NetworkConfig(campaign).expand()
+    if expandcampvars:
+        NetworkConfig(campaign).expand()
     return freeze(campaign) if frozen else campaign
 
 

--- a/hpcbench/cli/benumb.py
+++ b/hpcbench/cli/benumb.py
@@ -19,7 +19,7 @@ from . import cli_common
 def main(argv=None):
     """ben-umb entry point"""
     arguments = cli_common(__doc__, argv=argv)
-    driver = CampaignDriver(arguments['CAMPAIGN-DIR'])
+    driver = CampaignDriver(arguments['CAMPAIGN-DIR'], expandcampvars=False)
     driver(no_exec=True)
     if argv is not None:
         return driver

--- a/hpcbench/export/csvexport.py
+++ b/hpcbench/export/csvexport.py
@@ -25,7 +25,7 @@ class CSVExporter(object):
         :param ofile: a filename or None if stdout should be used
         """
         self.report = ReportNode(path)
-        self.campaign = from_file(path)
+        self.campaign = from_file(path, expandcampvars=False)
         self.ofile = ofile
 
     def export(self, fields=None):

--- a/hpcbench/export/es.py
+++ b/hpcbench/export/es.py
@@ -38,7 +38,7 @@ class ESExporter(object):
         :param hosts: Elasticsearch cluster
         :rtype: str or list or str
         """
-        self.campaign = from_file(path)
+        self.campaign = from_file(path, expandcampvars=False)
         self.report = ReportNode(path)
         self.hosts = hosts
 


### PR DESCRIPTION
Neither environment variables nor network section should be expanded when we
are traversing the campaign for exporting, reporting, etc. These actions are
typically done at a later point in time and not necessarily on the same
system and would fail when we try to expand the original environment.
NB: we should consider storing the campaign file in expanded form in the
report directory, cf. #220