### PR TITLE
Fix/metrics driver

### DIFF
--- a/hpcbench/benchmark/ior.py
+++ b/hpcbench/benchmark/ior.py
@@ -15,7 +15,7 @@ from hpcbench.toolbox.functools_ext import listify
 from hpcbench.toolbox.process import find_executable
 
 
-class Extractor(MetricsExtractor):
+class IORMetricsExtractor(MetricsExtractor):
     """Parser for IOR outputs
     """
 
@@ -58,9 +58,9 @@ class Extractor(MetricsExtractor):
     @cached_property
     def metrics(self):
         metrics = {}
-        for operation in Extractor.OPERATIONS:
-            for meta, desc in Extractor.METAS.items():
-                name = Extractor.get_meta_name(operation, desc.get('name') or meta)
+        for operation in IORMetricsExtractor.OPERATIONS:
+            for meta, desc in IORMetricsExtractor.METAS.items():
+                name = IORMetricsExtractor.get_meta_name(operation, desc.get('name') or meta)
                 metrics[name] = desc['metric']
         return metrics
 
@@ -68,16 +68,16 @@ class Extractor(MetricsExtractor):
         columns = None
         metrics = {}
         with open(self.stdout) as istr:
-            Extractor._skip_output_header(istr)
+            IORMetricsExtractor._skip_output_header(istr)
             for line in istr:
                 line = line.strip()
-                if line.startswith(Extractor.RESULTS_HEADER_START):
-                    columns = Extractor.parse_results_header(line)
+                if line.startswith(IORMetricsExtractor.RESULTS_HEADER_START):
+                    columns = IORMetricsExtractor.parse_results_header(line)
                 elif line == '':
                     # end of results
                     break
                 else:
-                    Extractor.parse_result_line(columns, line, metrics)
+                    IORMetricsExtractor.parse_result_line(columns, line, metrics)
         return metrics
 
     @classmethod
@@ -103,7 +103,7 @@ class Extractor(MetricsExtractor):
         :param header: content of the results header line
         :return: list of string providing columns
         """
-        header = Extractor.RE_MULTIPLE_SPACES.sub(' ', header)
+        header = IORMetricsExtractor.RE_MULTIPLE_SPACES.sub(' ', header)
         header = header.split(' ')
         return header
 
@@ -115,7 +115,7 @@ class Extractor(MetricsExtractor):
         :param line: string of results below the columns line
         :param metrics: output dict where metrics are written
         """
-        line = Extractor.RE_MULTIPLE_SPACES.sub(' ', line)
+        line = IORMetricsExtractor.RE_MULTIPLE_SPACES.sub(' ', line)
         line = line.split(' ')
         operation = line[0]
         assert len(line) == len(columns)
@@ -240,4 +240,4 @@ class IOR(Benchmark):
     @cached_property
     def metrics_extractors(self):
         # Use same extractor for all categories of commands
-        return Extractor()
+        return IORMetricsExtractor()

--- a/hpcbench/benchmark/ior.py
+++ b/hpcbench/benchmark/ior.py
@@ -60,7 +60,9 @@ class IORMetricsExtractor(MetricsExtractor):
         metrics = {}
         for operation in IORMetricsExtractor.OPERATIONS:
             for meta, desc in IORMetricsExtractor.METAS.items():
-                name = IORMetricsExtractor.get_meta_name(operation, desc.get('name') or meta)
+                name = IORMetricsExtractor.get_meta_name(
+                    operation, desc.get('name') or meta
+                )
                 metrics[name] = desc['metric']
         return metrics
 

--- a/hpcbench/driver/base.py
+++ b/hpcbench/driver/base.py
@@ -24,6 +24,9 @@ MAPPINGS = (dict, FrozenDict)
 ConstraintTag = namedtuple('ConstraintTag', ['name', 'constraint'])
 
 
+Top = namedtuple('top', ['campaign', 'node', 'logger', 'root', 'name'])
+
+
 def write_yaml_report(func):
     """Decorator used in campaign node post-processing
     """
@@ -159,9 +162,6 @@ class Leaf(Enumerator):
     @cached_property
     def children(self):
         return []
-
-
-Top = namedtuple('top', ['campaign', 'node', 'logger', 'root', 'name'])
 
 
 class ClusterWrapper(Cluster):

--- a/hpcbench/driver/base.py
+++ b/hpcbench/driver/base.py
@@ -125,7 +125,7 @@ class Enumerator(six.with_metaclass(ABCMeta, object)):
                 return func(self, *args, **kwargs)
             except Exception:
                 self.logger.exception('While executing benchmark')
-                if not self.catch_child_exception:
+                if not (self.catch_child_exception or False):
                     raise
 
         return _wrap

--- a/hpcbench/driver/benchmark.py
+++ b/hpcbench/driver/benchmark.py
@@ -166,7 +166,7 @@ class BenchmarkCategoryDriver(Enumerator):
             child_config.pop('children', None)
             runs.setdefault(self.category, []).append(child)
             with pushd(child):
-                MetricsDriver(self.campaign, self.benchmark)(**kwargs)
+                MetricsDriver(self, self.benchmark)(**kwargs)
         self.gather_metrics(runs)
 
     def _add_build_info(self, execution):
@@ -240,8 +240,9 @@ class MetricsDriver(object):
     built by a previous run
     """
 
-    def __init__(self, campaign, benchmark):
-        self.campaign = campaign
+    def __init__(self, parent, benchmark):
+        super(MetricsDriver, self).__init__(parent)
+        self.campaign = parent.campaign
         self.benchmark = benchmark
         with open(YAML_REPORT_FILE) as istr:
             self.report = yaml.safe_load(istr)
@@ -389,8 +390,7 @@ class FixedAttempts(Enumerator):
             driver = self.execution_layer()
             driver(**kwargs)
             if self.report['command_succeeded']:
-                mdriver = MetricsDriver(self.campaign, self.benchmark)
-                mdriver(**kwargs)
+                MetricsDriver(self, self.benchmark)(**kwargs)
             return self.report
 
         return _wrap


### PR DESCRIPTION
MetricsDriver was not derived from Enumerator or Leaf. As a result the exception handling was broken. I made this class to now subclass Leaf. When doing this I noticed that the `self.report` cached property is causing the generated yaml files to be broken. I am not entirely sure why this is happening in this case, but I fixed it by loading in `__call__()` the yaml report without converting the read dict into a `nameddict`.